### PR TITLE
Add 'current' command to show version in use.

### DIFF
--- a/src/test/cucumber/gvm/use_candidate.feature
+++ b/src/test/cucumber/gvm/use_candidate.feature
@@ -24,3 +24,16 @@ Feature: Use Candidate
 		And the candidate "grails" version "1.3.9" is in use
 		When I enter "gvm use grails 2.1.0"
 		Then the candidate "grails" version "2.1.0" should be in use
+
+	Scenario: Display current candidate version in use
+		Given the candidate "grails" version "2.1.0" is already installed
+		Given the candidate "grails" version "1.3.9" is already installed
+		And the candidate "grails" version "1.3.9" is in use
+		When I enter "gvm current grails"
+		Then I see "Using grails version 1.3.9"
+
+	Scenario: Display current candidate version when none is in use
+		Given the candidate "grails" version "2.1.0" is already installed
+		Given the candidate "grails" version "1.3.9" is already installed
+		When I enter "gvm current grails"
+		Then I see "Not using any version of grails"

--- a/src/test/resources/gvm/env.groovy
+++ b/src/test/resources/gvm/env.groovy
@@ -1,6 +1,11 @@
 import static cucumber.runtime.groovy.Hooks.*
 import static gvm.VertxUtils.*
 
+def gvmDir = System.getenv('GVM_DIR')
+if (!gvmDir) {
+	throw new RuntimeException("You must have the GVM_DIR environment variable set to run the tests")
+}
+
 gvmDir = new File(System.getenv('GVM_DIR'))
 
 server = null

--- a/srv/scripts/gvm
+++ b/srv/scripts/gvm
@@ -11,7 +11,7 @@ function help {
 	echo ""
 	echo "Usage: gvm <command> <candidate> [version]"
 	echo ""
-	echo "   command    :  install, uninstall, list, use, selfupdate or help"
+	echo "   command    :  install, uninstall, list, use, current, selfupdate or help"
 	echo "   candidate  :  $CANDIDATES"
 	echo "   version    :  optional, defaults to latest stable if not provided"
 	echo ""
@@ -139,7 +139,7 @@ if [ "$1" == "help" -o -z "$1" ]; then
 	exit 0
 fi
 
-if [ "$1" != "install" -a "$1" != "use" -a "$1" != "uninstall" -a "$1" != "list" -a "$1" != "help" -a "$1" != "selfupdate" ]; then
+if [ "$1" != "install" -a "$1" != "use" -a "$1" != "uninstall" -a "$1" != "list" -a "$1" != "current" -a "$1" != "help" -a "$1" != "selfupdate" ]; then
 	echo -e "\nInvalid command: $1"
 	help
 	exit 0
@@ -187,6 +187,16 @@ function gvm-use {
 	ln -s "$GVM_DIR/$CANDIDATE/$VERSION" "$GVM_DIR/$CANDIDATE/current"
 	echo ""
 	echo Using "$CANDIDATE" version "$VERSION"
+}
+
+function gvm-current {
+	CANDIDATE="$1"
+	determine_current_version "$CANDIDATE"
+	if [ -n "$CURRENT" ]; then
+		echo Using "$CANDIDATE" version "$CURRENT"
+	else
+		echo Not using any version of "$CANDIDATE"
+	fi
 }
 
 function gvm-list {


### PR DESCRIPTION
`rvm` has a simple `current` command that displays which version of Ruby is currently in use. This commit adds the same command to `gvm`.
