### PR TITLE
Add cucumber test for 'version' command.

### DIFF
--- a/src/test/cucumber/gvm/version.feature
+++ b/src/test/cucumber/gvm/version.feature
@@ -1,0 +1,5 @@
+Feature: Version
+
+	Scenario: Show the current version of gvm
+		When I enter "gvm version"
+		Then I see "Groovy enVironment Manager 0.8"


### PR DESCRIPTION
I've hard-coded the gvm version number in the test, because I can't think
of a way to parameterise it. At least it will fail obviously when the gvm
version changes.
