### PR TITLE
Add 'install' target to build.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,9 @@ task cleanInstall(type: Delete) {
 }
 
 task install(type: Copy, dependsOn: cleanInstall) {
-    from "srv/scripts"
+    from "srv/scripts", {
+        include "gvm"
+        include "**/*.sh"
+    }
     into installDir
 }


### PR DESCRIPTION
This allows developers to install their development versions of the gvm
scripts into ~/.gvm/bin.
