### PR TITLE
Fixed error while installing candidate on Cygwin.

### DIFF
--- a/srv/scripts/gvm
+++ b/srv/scripts/gvm
@@ -87,7 +87,11 @@ function download {
 
 function validate_zip {
 	ZIP_ARCHIVE="$1"
-	ZIP_OK=$(zip -T "$ZIP_ARCHIVE" | grep 'OK')
+	if [ "$TERM" == 'cygwin' ]; then
+		ZIP_OK=$(zip -T `cygpath -aw "$ZIP_ARCHIVE"` | grep 'OK')
+	else
+		ZIP_OK=$(zip -T "$ZIP_ARCHIVE" | grep 'OK')
+	fi
 	if [ -z "$ZIP_OK" ]; then
 		rm "$ZIP_ARCHIVE"
 		echo ""


### PR DESCRIPTION
Error message:
zip error: Nothing to do! ($userhome/.gvm/archives/$candidate.$version.zip)
Stop! The archive was corrupt and has been removed! Please try installing again.
