### PR TITLE
Add initial support for per-shell versions: issue #52

### DIFF
--- a/src/main/resources/scripts/gvm
+++ b/src/main/resources/scripts/gvm
@@ -6,7 +6,7 @@ PLATFORM=$(uname)
 # function definitions
 #
 
-function help {
+function __gvmtool_help {
 	CANDIDATES=$(curl -s "$GVM_SERVICE/candidates")
 	echo ""
 	echo "Usage: gvm <command> <candidate> [version]"
@@ -18,23 +18,23 @@ function help {
 	echo "eg: gvm install groovy"
 }
 
-function check_candidate_present {
+function __gvmtool_check_candidate_present {
 	if [ -z "$1" ]; then
 		echo -e "\nNo candidate provided."
-		help
-		exit 0
+		__gvmtool_help
+		return 1
 	fi
 }
 
-function check_version_present {
+function __gvmtool_check_version_present {
 	if [ -z "$1" ]; then
 		echo -e "\nNo candidate version provided."
-		help
-		exit 0
+		__gvmtool_help
+		return 1
 	fi
 }
 
-function determine_version {
+function __gvmtool_determine_version {
 	if [ -z "$1" ]; then
 		VERSION=$(curl -s "$GVM_SERVICE/candidates/$CANDIDATE/default")
 	else
@@ -44,12 +44,12 @@ function determine_version {
 		else
 			echo ""
 			echo "Stop! $1 is not a valid $CANDIDATE version."
-			exit 0
+			return 1
 		fi
 	fi
 }
 
-function build_version_csv {
+function __gvmtool_build_version_csv {
 	CANDIDATE="$1"
 	CSV=""
 	for version in $(ls -1 "$GVM_DIR/$CANDIDATE"); do
@@ -60,12 +60,12 @@ function build_version_csv {
 	CSV=${CSV%?}
 }
 
-function determine_current_version {
+function __gvmtool_determine_current_version {
 	CANDIDATE="$1"
 	CURRENT=$(readlink "$GVM_DIR/$CANDIDATE/current" | sed -e "s_$GVM_DIR/$CANDIDATE/__g")
 }
 
-function download {
+function __gvmtool_download {
 	CANDIDATE="$1"
 	VERSION="$2"
 	mkdir -p "$GVM_DIR/archives"
@@ -76,27 +76,27 @@ function download {
 		DOWNLOAD_URL="$GVM_SERVICE/download/$CANDIDATE/$VERSION?platform=$PLATFORM"
 		ZIP_ARCHIVE="$GVM_DIR/archives/$CANDIDATE-$VERSION.zip"
 		curl -L "$DOWNLOAD_URL" > "$ZIP_ARCHIVE"
-		validate_zip "$ZIP_ARCHIVE"
+		__gvmtool_validate_zip "$ZIP_ARCHIVE" || return 1
 	else
 		echo ""
 		echo "Found a previously downloaded $CANDIDATE $VERSION archive. Not downloading it again..."
-		validate_zip "$GVM_DIR/archives/$CANDIDATE-$VERSION.zip"
+		__gvmtool_validate_zip "$GVM_DIR/archives/$CANDIDATE-$VERSION.zip" || return 1
 	fi
 	echo ""
 }
 
-function validate_zip {
+function __gvmtool_validate_zip {
 	ZIP_ARCHIVE="$1"
 	ZIP_OK=$(unzip -t "$ZIP_ARCHIVE" | grep 'No errors detected in compressed data')
 	if [ -z "$ZIP_OK" ]; then
 		rm "$ZIP_ARCHIVE"
 		echo ""
 		echo "Stop! The archive was corrupt and has been removed! Please try installing again."
-		exit 0
+		return 1
 	fi
 }
 
-function no_connection {
+function __gvmtool_no_connection {
 	echo "                                                         "
 	echo "---------------------------------------------------------"
 	echo "                                                         "
@@ -104,10 +104,9 @@ function no_connection {
 	echo "     If the problem persists please notify: @gvmtool     "
 	echo "                                                         "
 	echo "---------------------------------------------------------"
-	exit 0
 }
 
-function default_environment_variables {
+function __gvmtool_default_environment_variables {
 	if [ ! "$GVM_SERVICE" ]; then
 		GVM_SERVICE="http://localhost:8080"
 	fi
@@ -117,15 +116,15 @@ function default_environment_variables {
 	fi
 }
 
-function server_broadcast {
+function __gvmtool_server_broadcast {
 	BROADCAST_LIVE=$(curl -s "$GVM_SERVICE/broadcast/$GVM_VERSION")
 	if [ ! "$BROADCAST_LIVE" ]; then
-		no_connection
-		exit 0
+		__gvmtool_no_connection
+		return 1
 	fi
 }
 
-function check_upgrade_available {
+function __gvmtool_check_upgrade_available {
 	UPGRADE_AVAILABLE=""
 	UPGRADE_NOTICE=$(echo "$BROADCAST_LIVE" | grep 'Your version of GVM is out of date!')
 	if [[ "$UPGRADE_NOTICE" && "$COMMAND" != 'selfupdate' ]]; then
@@ -133,7 +132,7 @@ function check_upgrade_available {
 	fi
 }
 
-function display_broadcast {
+function __gvmtool_display_broadcast {
 	COMMAND="$1"
 	BROADCAST_FILE="$GVM_DIR/var/broadcast"
 	if [ -f "$BROADCAST_FILE" ]; then
@@ -145,16 +144,16 @@ function display_broadcast {
 		echo "$BROADCAST_LIVE" > "$BROADCAST_FILE"
 		echo "$BROADCAST_LIVE"
 	fi
-
-	if [ "$1" == "help" -o -z "$1" ]; then
-		help
-		exit 0
-	fi
 }
 
-function link_candidate_version {
+function __gvmtool_link_candidate_version {
 	CANDIDATE="$1"
 	VERSION="$2"
+
+	UPPER_CANDIDATE=`echo "$CANDIDATE" | tr '[:lower:]' '[:upper:]'`
+	export "${UPPER_CANDIDATE}_HOME"="$GVM_DIR/$CANDIDATE/$VERSION"
+	export PATH=`echo $PATH | sed -E "s!$GVM_DIR/$CANDIDATE/([0-9][^/]+|current)!$GVM_DIR/$CANDIDATE/$VERSION!g"`
+
 	if [ -L "$GVM_DIR/$CANDIDATE/current" ]; then
 		unlink "$GVM_DIR/$CANDIDATE/current"
 	fi
@@ -163,10 +162,10 @@ function link_candidate_version {
 	echo Using "$CANDIDATE" version "$VERSION"
 }
 
-function install_candidate_version {
+function __gvmtool_install_candidate_version {
 	CANDIDATE="$1"
 	VERSION="$2"
-	download "$CANDIDATE" "$VERSION"
+	__gvmtool_download "$CANDIDATE" "$VERSION" || return 1
 	echo "Installing: $CANDIDATE $VERSION"
 
 	mkdir -p "$GVM_DIR/$CANDIDATE"
@@ -176,51 +175,34 @@ function install_candidate_version {
 	echo "Done installing!"
 	echo ""
 }
-
-#
-# Various sanity checks and default settings
-#
-
-default_environment_variables
-mkdir -p "$GVM_DIR"
-
-server_broadcast
-check_upgrade_available
-if [[ "$UPGRADE_AVAILABLE" && "$1" != "broadcast" ]]; then
-	echo "$BROADCAST_LIVE"
-	echo ""
-else
-	display_broadcast "$1"
-fi
-
 #
 # Command functions
 #
 
-function gvm-install {
+function __gvmtool_install {
 	CANDIDATE="$1"
-	check_candidate_present "$CANDIDATE"
-	determine_version "$2"
+	__gvmtool_check_candidate_present "$CANDIDATE" || return 1
+	__gvmtool_determine_version "$2" || return 1
 
 	if [ -d "$GVM_DIR/$CANDIDATE/$VERSION" ]; then
 		echo ""
 		echo "Stop! $CANDIDATE $VERSION is already installed."
-		exit 0
+		return 1
 	fi
 
-	install_candidate_version "$CANDIDATE" "$VERSION"
+	__gvmtool_install_candidate_version "$CANDIDATE" "$VERSION" || return 1
 
 	echo -n "Do you want to use $CANDIDATE $VERSION now? (Y/n): "
 	read USE
 	if [[ -z "$USE" || "$USE" == "y" || "$USE" == "Y" ]]; then
-		link_candidate_version "$CANDIDATE" "$VERSION"
+		__gvmtool_link_candidate_version "$CANDIDATE" "$VERSION"
 	fi
 }
 
-function gvm-use {
+function __gvmtool_use {
 	CANDIDATE="$1"
-	check_candidate_present "$CANDIDATE"
-	determine_version "$2"
+	__gvmtool_check_candidate_present "$CANDIDATE" || return 1
+	__gvmtool_determine_version "$2" || return 1
 
 	if [ ! -d "$GVM_DIR/$CANDIDATE/$VERSION" ]; then
 		echo ""
@@ -230,17 +212,17 @@ function gvm-use {
 		if [[ -z "$INSTALL" || "$INSTALL" == "y" || "$INSTALL" == "Y" ]]; then
 			install_candidate_version "$CANDIDATE" "$VERSION"
 		else
-			exit 0
+			return 1
 		fi
 	fi
 
-	link_candidate_version "$CANDIDATE" "$VERSION"
+	__gvmtool_link_candidate_version "$CANDIDATE" "$VERSION"
 }
 
-function gvm-current {
+function __gvmtool_current {
 	CANDIDATE="$1"
-	check_candidate_present "$CANDIDATE"
-	determine_current_version "$CANDIDATE"
+	__gvmtool_check_candidate_present "$CANDIDATE" || return 1
+	__gvmtool_determine_current_version "$CANDIDATE" || return 1
 	if [ -n "$CURRENT" ]; then
 		echo Using "$CANDIDATE" version "$CURRENT"
 	else
@@ -248,20 +230,20 @@ function gvm-current {
 	fi
 }
 
-function gvm-list {
+function __gvmtool_list {
 	CANDIDATE="$1"
-	check_candidate_present "$CANDIDATE"
-	build_version_csv "$CANDIDATE"
-	determine_current_version "$CANDIDATE"
+	__gvmtool_check_candidate_present "$CANDIDATE" || return 1
+	__gvmtool_build_version_csv "$CANDIDATE" || return 1
+	__gvmtool_determine_current_version "$CANDIDATE" || return 1
 	FRAGMENT=$(curl -s "$GVM_SERVICE/candidates/$CANDIDATE/list?platform=$PLATFORM&current=$CURRENT&installed=$CSV")
 	echo "$FRAGMENT"
 }
 
-function gvm-uninstall {
+function __gvmtool_uninstall {
 	CANDIDATE="$1"
 	VERSION="$2"
-	check_candidate_present "$CANDIDATE"
-	check_version_present "$VERSION"
+	__gvmtool_check_candidate_present "$CANDIDATE" || return 1
+	__gvmtool_check_version_present "$VERSION" || return 1
 	CURRENT=$(readlink "$GVM_DIR/$CANDIDATE/current" | sed -e "s_$GVM_DIR/$CANDIDATE/__g")
 	if [ -h "$GVM_DIR/$CANDIDATE/current" -a "$VERSION" == "$CURRENT" ]; then
 		echo ""
@@ -277,11 +259,11 @@ function gvm-uninstall {
 	fi
 }
 
-function gvm-version {
+function __gvmtool_version {
 	echo "Groovy enVironment Manager $GVM_VERSION"
 }
 
-function gvm-broadcast {
+function __gvmtool_broadcast {
 	if [ "$BROADCAST_HIST" ]; then
 		echo "$BROADCAST_HIST"
 	else
@@ -289,30 +271,55 @@ function gvm-broadcast {
 	fi
 }
 
-function gvm-selfupdate {
+function __gvmtool_selfupdate {
 	curl -s "$GVM_SERVICE/selfupdate" | bash
 }
 
 # INSERT NEW COMMANDS BEFORE HERE
 
-# Check whether the command exists
-
-CMD_TYPE=`type -t gvm-"$1"`
-
-if [ -z $CMD_TYPE ]; then
-	echo -e "\nInvalid command: $1"
-	help
-	exit 0
-fi
-
-# Check whether the candidate exists
-
-CANDIDATE_VALID=$(curl -s "$GVM_SERVICE/candidates/$2")
-if [ "$CANDIDATE_VALID" == 'invalid' ]; then
-	echo -e "\nStop! $2 is not a valid candidate."
-	exit 0
-fi
-
 # Main command
+function gvm {
+	#
+	# Various sanity checks and default settings
+	#
+	__gvmtool_default_environment_variables
+	mkdir -p "$GVM_DIR"
 
-gvm-"$1" "$2" "$3"
+	__gvmtool_server_broadcast || return 1
+	__gvmtool_check_upgrade_available
+	if [[ "$UPGRADE_AVAILABLE" && "$1" != "broadcast" ]]; then
+		echo "$BROADCAST_LIVE"
+		echo ""
+	else
+		__gvmtool_display_broadcast "$1"
+	fi
+
+	# Check whether the command exists as an internal function...
+	CMD_TYPE=`type -t __gvmtool_"$1"`
+
+	# ...or as a script on the path.
+	SCRIPT_PATH="$GVM_DIR/plugins/gvm-$1.sh"
+
+	if [[ -z $CMD_TYPE && ! -f $SCRIPT_PATH ]]; then
+		echo -e "\nInvalid command: $1"
+		__gvmtool_help
+		return 1
+	fi
+
+	# Check whether the candidate exists
+	CANDIDATE_VALID=$(curl -s "$GVM_SERVICE/candidates/$2")
+	if [ "$CANDIDATE_VALID" == 'invalid' ]; then
+		echo -e "\nStop! $2 is not a valid candidate."
+		return 1
+	fi
+
+	# Execute the requested command
+	if [ $CMD_TYPE ]; then
+		# It's available as a shell function
+		__gvmtool_"$1" "$2" "$3"
+	else
+		# It's a shell script in the plugins directory
+		$SCRIPT_PATH "$1" "$2" "$3"
+	fi
+}
+

--- a/src/main/resources/scripts/gvm-init.sh
+++ b/src/main/resources/scripts/gvm-init.sh
@@ -2,12 +2,29 @@
 
 export GVM_SERVICE="@GVM_SERVICE@"
 
-PATH="$HOME/.gvm/bin:$PATH"
+if [ -z "$GVM_DIR" ]; then
+	export GVM_DIR="$HOME/.gvm"
+fi
 
-GROOVY_HOME="$HOME/.gvm/groovy/current"
-GRAILS_HOME="$HOME/.gvm/grails/current"
-GRIFFON_HOME="$HOME/.gvm/griffon/current"
-GRADLE_HOME="$HOME/.gvm/gradle/current"
-VERTX_HOME="$HOME/.gvm/vert.x/current"
+PATH="$GVM_DIR/bin:$PATH"
+
+GROOVY_HOME="$GVM_DIR/groovy/current"
+GRAILS_HOME="$GVM_DIR/grails/current"
+GRIFFON_HOME="$GVM_DIR/griffon/current"
+GRADLE_HOME="$GVM_DIR/gradle/current"
+VERTX_HOME="$GVM_DIR/vert.x/current"
 
 export PATH="$GROOVY_HOME/bin:$GRAILS_HOME/bin:$GRIFFON_HOME/bin:$GRADLE_HOME/bin:$VERTX_HOME/bin:$PATH"
+
+# Source the main `gvm` script.
+source "$GVM_DIR/bin/gvm"
+
+# Source any plugin files whose names begin with 'sourced-'
+if [ -d "$GVM_DIR/plugins" ]; then
+    for f in $GVM_DIR/plugins/sourced-*.sh; do
+        if [ -r $f ]; then
+            source $f
+        fi
+    done
+    unset f
+fi

--- a/src/test/cucumber/gvm/version.feature
+++ b/src/test/cucumber/gvm/version.feature
@@ -3,3 +3,9 @@ Feature: Version
 	Scenario: Show the current version of gvm
 		When I enter "gvm version"
 		Then I see "Groovy enVironment Manager 0.8.3"
+
+	Scenario: The local gvm is out of date
+		Given no prior Broadcast was received
+		And a new Broadcast "This is a LIVE Broadcast!" is available
+		When I enter "gvm broadcast"
+		Then I see only "This is a LIVE Broadcast!"


### PR DESCRIPTION
In order to make version changes only apply to the current shell, I had to make
the `gvm-init.sh` script source the `gvm` one. This meant replacing all `exit`
calls in the later with `return`s and changing the name of the functions by
prefixing them with `__gvmtool_` (to avoid the functions appearing in bash
auto-completion by accident).

To help with some of the internals, `gvm-init.sh` now exports the `GVM_DIR`
variable if it hasn't already been set by the user. This makes it availabe to
`gvm` and any plugin scripts that get executed in sub-shells.

`gvm-init.sh` also sources any scripts in `$GVM_DIR/plugins` whose name begins
with `sourced-` and ends with `.sh`. This allows users to extend the system
with extra functionality, although they are required to name their functions
with `__gvmtool_<command>`. Plugins can also be implemented as straight
`gvm-<command>.sh` scripts, but these manually need to source the `gvm` script
if they want access to its internal functions, such as `__gvmtool_help`.

One thing that remains unresolved is whether to support the symlink approach
as well, and if so, how. Another issue is how to determine what happens at
switch time. At the moment, the script just assumes that it needs to change
the value of the `${CANDIDATE}_HOME` environment variable, but is that the
case for all candidates? Probably not.
