### PR TITLE
Use "which" command exit status instead of the output: issue #106

### DIFF
--- a/src/main/resources/scripts/install.sh
+++ b/src/main/resources/scripts/install.sh
@@ -36,7 +36,7 @@ gvm_bashrc="${HOME}/.bashrc"
 gvm_zshrc="${HOME}/.zshrc"
 gvm_init_snippet=$( cat << EOF
 #THIS MUST BE AT THE END OF THE FILE FOR GVM TO WORK!!!
-[[ -s "${GVM_DIR}/bin/gvm-init.sh" && ! \$(which gvm-init.sh) ]] && source "${GVM_DIR}/bin/gvm-init.sh"
+[ -s "${GVM_DIR}/bin/gvm-init.sh" ] && which gvm-init.sh >/dev/null 2>&1 || source "${GVM_DIR}/bin/gvm-init.sh"
 EOF
 )
 


### PR DESCRIPTION
Fix for issue #106 

Checking the presence or absence of the which's output in .zshrc.

```
[[ -s "${GVM_DIR}/bin/gvm-init.sh" && ! $(which gvm-init.sh) ]] && source "${GVM_DIR}/bin/gvm-init.sh"
```

The "which" of zsh always prints a message to stdout even if a command is not found.

```
% which gvm-init.sh
gvm-init.sh not found
```

Therefore, should be check the exit status of the command.
