### PR TITLE
Issue #107 GVM doesn't work on Cygwin quickfix

### DIFF
--- a/src/main/resources/scripts/install.sh
+++ b/src/main/resources/scripts/install.sh
@@ -164,7 +164,16 @@ echo "Download script archive..."
 curl -s "${GVM_SERVICE}/res?platform=${GVM_PLATFORM}" > "${gvm_zip_file}"
 
 echo "Extract script archive..."
-unzip -qo "${gvm_zip_file}" -d "${gvm_stage_folder}"
+
+if [ `uname -o` = "Cygwin" ]
+then
+	echo "Cygwin detected - normalizing paths for unzip..."
+	unzip -qo $(cygpath -w "${gvm_zip_file}") -d $(cygpath -w "${gvm_stage_folder}")	
+else
+	unzip -qo "${gvm_zip_file}" -d "${gvm_stage_folder}"
+fi
+
+
 
 echo "Install scripts..."
 mv "${gvm_stage_folder}/gvm-init.sh" "${gvm_bin_folder}"


### PR DESCRIPTION
This solves problem only in case when unzip comes from oracledb (both I and author of issue struggle with this). It's all about that unzip coming with oracle is the same unzip like in linux (or cygwin when installed) but compiled for windows so it is only accept windows file path (which is what my fix actually do - convert linux path to windows path).

Maybe it should be better solution to check if used unzip is that should be ie. for example use

expr match "$(unzip)" "._Original by Info-ZIP_" 
unzip help contains text "Original by Info-ZIP") 

which tell us if we are gonna use right unzip program - it expr check fails it means that our path is poluted by other incompatible version of unzip program and we should tell the user about...
