### PR TITLE
Add stdout from bash processes to test reports

### DIFF
--- a/src/test/resources/gvm/env.groovy
+++ b/src/test/resources/gvm/env.groovy
@@ -48,7 +48,11 @@ Before(){
     }
 }
 
-After(){
+After(){ scenario ->
+    def output = bash?.output
+    if (output) {
+        scenario.write("\nOutput: \n${output}")
+    }
 	bash?.stop()
     cleanUp()
 }


### PR DESCRIPTION
Its quite hard to debug what went wrong if a test fails so it would be very
helpful to have a record somewhere of the stdout from bash.  This patch
appends it to the test report.
