### PR TITLE
Add some hooks, searching in GVM_DIR/hooks

### DIFF
--- a/src/test/cucumber/gvm/install_candidate.feature
+++ b/src/test/cucumber/gvm/install_candidate.feature
@@ -54,4 +54,24 @@ Feature: Install Candidate
     Then I see "Stop! The archive was corrupt and has been removed! Please try installing again."
     And the candidate "grails" version "1.3.6" is not installed
     And the archive for candidate "grails" version "1.3.6" is removed
+
+  Scenario: Default post install hooks are executed if present
+    Given there is a post install hook for "grails"
+    When I enter "gvm install grails 2.1.0" and answer "y"
+    Then I see "Running post install!"
+	
+  Scenario: Version specific post install hooks are executed if present
+    Given there is a post install hook for "grails" version "2.1.0"
+    When I enter "gvm install grails 2.1.0" and answer "y"
+    Then I see "Running specific post install!"
+	
+  Scenario: Version parent post install hooks are executed if present
+    Given there is a post install hook for "grails" version "2"
+    When I enter "gvm install grails 2.1.0" and answer "y"
+    Then I see "Running specific post install!"
+	
+  Scenario: Post install hooks fallback to global default
+    Given there is a global post install hook
+    When I enter "gvm install grails 2.1.0" and answer "y"
+    Then I see "Running system post install!"
 	

--- a/src/test/resources/gvm/installation_steps.groovy
+++ b/src/test/resources/gvm/installation_steps.groovy
@@ -83,6 +83,24 @@ And(~'^I have configured "([^"]*)" to "([^"]*)"$') { String configName, String f
     configFile.write "${configName}=${flag}"
 }
 
+Given(~'^there is a post install hook for "([^"]*)"$') { String candidate ->
+    def hookFile = new File("$gvmDir/hooks/$candidate/default/post-install.sh")
+    hookFile.parentFile.mkdirs()
+    hookFile.write "echo Running post install!"    
+}
+
+Given(~'^there is a post install hook for "([^"]*)" version "([^"]*)"$') { String candidate, String version ->
+    def hookFile = new File("$gvmDir/hooks/$candidate/$version/post-install.sh")
+    hookFile.parentFile.mkdirs()
+    hookFile.write "echo Running specific post install!"    
+}
+
+Given(~'^there is a global post install hook$') { ->
+    def hookFile = new File("$gvmDir/hooks/post-install.sh")
+    hookFile.parentFile.mkdirs()
+    hookFile.write "echo Running system post install!"    
+}
+
 private prepareCandidateFolder(String baseDir, String candidate, String version) {
     def directory = "$baseDir/$candidate/$version"
     prepareCandidateBinFolder directory, candidate, version


### PR DESCRIPTION
E.g. for grails 2.1.0 the system looks for a post-install.sh in

hooks/grails/2.1.0 hooks/grails/2.1 hooks/grails/2 hooks/grails/default hooks

It executes the first one it finds and then exits the loop.

N.B. this patch does not install any hooks.  We need to decide how that could
be done in a data-driven way.  Registering a hooks.zip per candidate in Mongo
might be one option, and unzipping it during an installation.
