### PR TITLE
Add post-install hooks

### DIFF
--- a/src/test/cucumber/gvm/install_candidate.feature
+++ b/src/test/cucumber/gvm/install_candidate.feature
@@ -54,4 +54,24 @@ Feature: Install Candidate
     Then I see "Stop! The archive was corrupt and has been removed! Please try installing again."
     And the candidate "grails" version "1.3.6" is not installed
     And the archive for candidate "grails" version "1.3.6" is removed
+
+  Scenario: Default post install hooks are executed if present
+    Given there is a post install hook for "grails"
+    When I enter "gvm install grails 2.1.0" and answer "y"
+    Then I see "Running post install!"
+	
+  Scenario: Version specific post install hooks are executed if present
+    Given there is a post install hook for "grails" version "2.1.0"
+    When I enter "gvm install grails 2.1.0" and answer "y"
+    Then I see "Running specific post install!"
+	
+  Scenario: Version parent post install hooks are executed if present
+    Given there is a post install hook for "grails" version "2"
+    When I enter "gvm install grails 2.1.0" and answer "y"
+    Then I see "Running specific post install!"
+	
+  Scenario: Post install hooks fallback to global default
+    Given there is a global post install hook
+    When I enter "gvm install grails 2.1.0" and answer "y"
+    Then I see "Running system post install!"
 	

--- a/src/test/resources/gvm/installation_steps.groovy
+++ b/src/test/resources/gvm/installation_steps.groovy
@@ -83,6 +83,24 @@ And(~'^I have configured "([^"]*)" to "([^"]*)"$') { String configName, String f
     configFile.write "${configName}=${flag}"
 }
 
+Given(~'^there is a post install hook for "([^"]*)"$') { String candidate ->
+    def hookFile = new File("$gvmDir/hooks/$candidate/default/post-install.sh")
+    hookFile.parentFile.mkdirs()
+    hookFile.write "echo Running post install!"    
+}
+
+Given(~'^there is a post install hook for "([^"]*)" version "([^"]*)"$') { String candidate, String version ->
+    def hookFile = new File("$gvmDir/hooks/$candidate/$version/post-install.sh")
+    hookFile.parentFile.mkdirs()
+    hookFile.write "echo Running specific post install!"    
+}
+
+Given(~'^there is a global post install hook$') { ->
+    def hookFile = new File("$gvmDir/hooks/post-install.sh")
+    hookFile.parentFile.mkdirs()
+    hookFile.write "echo Running system post install!"    
+}
+
 private prepareCandidateFolder(String baseDir, String candidate, String version) {
     def directory = "$baseDir/$candidate/$version"
     prepareCandidateBinFolder directory, candidate, version


### PR DESCRIPTION
Post install hooks are needed for example when a candidate has an available .zip file but no bin directory, or the bin dir needs to be modified (e.g. chmod +x).  I'm open to suggestion about where to store the hooks - they need to be candidate and possibly versions specific and available to all users (although possibly overridable locally - could be a separate issue).
