### PR TITLE
Remove hard coded list of candidates from gvm-help

### DIFF
--- a/src/main/resources/scripts/gvm-help.sh
+++ b/src/main/resources/scripts/gvm-help.sh
@@ -21,7 +21,7 @@ function __gvmtool_help {
 	echo "Usage: gvm <command> <candidate> [version]"
 	echo ""
 	echo "   command    :  install, uninstall, list, use, current, version, default, selfupdate, broadcast or help"
-	echo "   candidate  :  groovy, grails, griffon, gradle, vertx"
+	echo "   candidate  :  $(echo "${GVM_CANDIDATES[@]:-${GVM_CANDIDATES_DEFAULT[@]}}" | sed -E 's/ /, /g')"
 	echo "   version    :  optional, defaults to latest stable if not provided"
 	echo ""
 	echo "eg: gvm install groovy"


### PR DESCRIPTION
One thing we missed in #117 was the help message.  This patch
fixes it to be dynamic depending on the value of 
GVM_CANDIDATES.
