### PR TITLE
prevent displaying 'which' error message

### DIFF
--- a/src/main/resources/scripts/install.sh
+++ b/src/main/resources/scripts/install.sh
@@ -36,7 +36,7 @@ gvm_platform=$(uname -o)
 
 gvm_init_snippet=$( cat << EOF
 #THIS MUST BE AT THE END OF THE FILE FOR GVM TO WORK!!!
-[[ -s "${GVM_DIR}/src/gvm-init.sh" && -z \$(which gvm-init.sh | grep '/gvm-init.sh') ]] && source "${GVM_DIR}/src/gvm-init.sh"
+[[ -s "${GVM_DIR}/src/gvm-init.sh" && -z \$(which gvm-init.sh 2>/dev/null | grep '/gvm-init.sh') ]] && source "${GVM_DIR}/src/gvm-init.sh"
 EOF
 )
 


### PR DESCRIPTION
redirect which stderr to /dev/null to prevent "/usr/bin/which: no gvm-init.sh in (...)"
