### PR TITLE
A typo on line 91 was causing OS X to pick up an incorrect sed expression.

### DIFF
--- a/src/main/bash/gvm-common.sh
+++ b/src/main/bash/gvm-common.sh
@@ -88,7 +88,7 @@ function __gvmtool_determine_current_version {
 	CANDIDATE="$1"
 	if [[ "${solaris}" == true ]]; then
 		CURRENT=$(echo $PATH | gsed -r "s|.gvm/${CANDIDATE}/([^/]+)/bin|!!\1!!|1" | gsed -r "s|^.*!!(.+)!!.*$|\1|g")
-	elif [[ $"${darwin}" == true ]]; then
+	elif [[ "${darwin}" == true ]]; then
 		CURRENT=$(echo $PATH | sed -E "s|.gvm/${CANDIDATE}/([^/]+)/bin|!!\1!!|1" | sed -E "s|^.*!!(.+)!!.*$|\1|g")
 	else
 		CURRENT=$(echo $PATH | sed -r "s|.gvm/${CANDIDATE}/([^/]+)/bin|!!\1!!|1" | sed -r "s|^.*!!(.+)!!.*$|\1|g")


### PR DESCRIPTION
A typo on line 91 was causing OS X to pick up an incorrect sed expression.
