### PR TITLE
Improving usability - support for mnemonics and omitting commands

### DIFF
--- a/src/main/bash/gvm-main.sh
+++ b/src/main/bash/gvm-main.sh
@@ -59,83 +59,73 @@ function gvm {
 		source "${GVM_DIR}/etc/config"
 	fi
 
-    command="$1"
-    candidate="$2"
+    COMMAND="$1"
+    CANDIDATE="$2"
     shift; shift
 
  	# no command provided
-	if [[ -z "$command" ]]; then
+	if [[ -z "$COMMAND" ]]; then
 		__gvmtool_help
 		return 1
 	fi
 
-    case "$command" in
+    case "$COMMAND" in
         ls)
-            command="list";;
+            COMMAND="list";;
         h)
-            command="help";;
+            COMMAND="help";;
         v)
-            command="version";;
+            COMMAND="version";;
         u)
-            command="use";;
+            COMMAND="use";;
         remove)
-            command="uninstall";;
+            COMMAND="uninstall";;
         cur)
-            command="current";;
+            COMMAND="current";;
         def)
-            command="default";;
-        groovy) # assumes the command use, if ommitted
-            command="use"; candidate="groovy";;
-        grails)
-            command="use"; candidate="grails";;
-        gradle)
-            command="use"; candidate="gradle";;
-        lazybones)
-            command="use"; candidate="lazybones";;
-        vertx)
-            command="use"; candidate="vertx";;
+            COMMAND="default";;
     esac
 
 	# Check if it is a valid command
 	CMD_FOUND=""
-	CMD_TARGET="${GVM_DIR}/src/gvm-$command.sh"
+	CMD_TARGET="${GVM_DIR}/src/gvm-${COMMAND}.sh"
 	if [[ -f "${CMD_TARGET}" ]]; then
 		CMD_FOUND="${CMD_TARGET}"
 	fi
 
 	# Check if it is a sourced function
-	CMD_TARGET="${GVM_DIR}/ext/gvm-$command.sh"
+	CMD_TARGET="${GVM_DIR}/ext/gvm-${COMMAND}"
 	if [[ -f "${CMD_TARGET}" ]]; then
 		CMD_FOUND="${CMD_TARGET}"
 	fi
 
 	# couldn't find the command
 	if [[ -z "${CMD_FOUND}" ]]; then
-		echo "Invalid command: $command"
+		echo "Invalid command: ${COMMAND}"
 		__gvmtool_help
 	fi
 
 	# Check whether the candidate exists
-	if [[ -n "$candidate" && "$command" != "offline" && -z $(echo ${GVM_CANDIDATES[@]} | grep -w "$candidate") ]]; then
-		echo -e "\nStop! $candidate is not a valid candidate."
+	if [[ -n "${CANDIDATE}" && "${COMMAND}" != "offline" && -z $(echo ${GVM_CANDIDATES[@]} | grep -w "${CANDIDATE}") ]]; then
+		echo -e "\nStop! ${CANDIDATE} is not a valid candidate."
 		return 1
 	fi
 
-	if [[ "$command" == "offline" &&  -z "$candidate" ]]; then
+	if [[ "${COMMAND}" == "offline" &&  -z "${CANDIDATE}" ]]; then
 		echo -e "\nStop! Specify a valid offline mode."
-	elif [[ "$command" == "offline" && ( -z $(echo "enable disable" | grep -w "$candidate")) ]]; then
-		echo -e "\nStop! $candidate is not a valid offline mode."
+	elif [[ "${COMMAND}" == "offline" && ( -z $(echo "enable disable" | grep -w "${CANDIDATE}")) ]]; then
+		echo -e "\nStop! ${CANDIDATE} is not a valid offline mode."
 	fi
 
 	# Check whether the command exists as an internal function...
 	#
 	# NOTE Internal commands use underscores rather than hyphens,
 	# hence the name conversion as the first step here.
-	CONVERTED_CMD_NAME=$(echo "$command" | tr '-' '_')
+	CONVERTED_CMD_NAME=$(echo "${COMMAND}" | tr '-' '_')
 
 	# Execute the requested command
 	if [ -n "${CMD_FOUND}" ]; then
 		# It's available as a shell function
-		__gvmtool_"${CONVERTED_CMD_NAME}" "$candidate" $@
+		__gvmtool_"${CONVERTED_CMD_NAME}" "${CANDIDATE}" $@
 	fi
 }

--- a/src/test/cucumber/gvm/shortcuts.feature
+++ b/src/test/cucumber/gvm/shortcuts.feature
@@ -1,0 +1,52 @@
+Feature: Shortcuts
+
+  Background:
+    Given the internet is reachable
+
+  Scenario: Shortcut - List an uninstalled available Version
+    Given I do not have a "grails" candidate installed
+    When I enter "gvm ls grails"
+    Then I see "Available Grails Versions"
+    And I see "     2.1.0"
+
+  Scenario: Shortcut - Ask for help
+    When I enter "gvm h"
+    Then I see "Usage: gvm <command> <candidate> [version]"
+
+  Scenario: Shortcut - Display current candidate version in use
+    Given the candidate "grails" version "1.3.9" is already installed and default
+    When I enter "gvm cur grails"
+    Then I see "Using grails version 1.3.9"
+
+  Scenario: Shortcut - Display current candidate versions
+    Given the candidate "groovy" version "2.0.5" is already installed and default
+    And the candidate "grails" version "2.1.0" is already installed and default
+    When I enter "gvm cur"
+    Then I see "Using:"
+    And I see "grails: 2.1.0"
+    And I see "groovy: 2.0.5"
+
+  Scenario: Shortcut - Uninstall a local development version
+    Given the candidate "groovy" version "2.1-SNAPSHOT" is already linked to "/tmp/groovy-core"
+    When I enter "gvm remove groovy 2.1-SNAPSHOT"
+    Then I see "Uninstalling groovy 2.1-SNAPSHOT"
+    And the candidate "groovy" version "2.1-SNAPSHOT" is not installed
+
+  Scenario: Shortcut - Show the current version of gvm
+    When I enter "gvm version"
+    Then I see "Groovy enVironment Manager x.y.z"
+
+  Scenario: Shortcut - Use a candidate version that is installed
+    Given the candidate "grails" version "2.1.0" is already installed and default
+    And the candidate "grails" version "1.3.9" is already installed but not default
+    When I enter "gvm u grails 1.3.9"
+    Then I see "Using grails version 1.3.9 in this shell."
+    Then the candidate "grails" version "1.3.9" should be in use
+    And the candidate "grails" version "2.1.0" should be the default
+
+  Scenario: Shortcut - Default a candidate version that is installed and not default
+    And the candidate "groovy" version "2.0.5" is already installed but not default
+    When I enter "gvm def groovy 2.0.5"
+    Then I see "Default groovy version set to 2.0.5"
+    And the candidate "groovy" version "2.0.5" should be the default
+


### PR DESCRIPTION
Hi, folks!

I've been using GVM for some time now, it's an awesome tool -- thanks a lot for the great work! :)

Here I want to propose some small changes in the way the commands are dealt.
This patch adds some small usability improvements, namely, it enables using shorter names for commands and also allows to omit the command 'use' -- if only the candidate is provided.

Therefore:

`gvm ls griffon` is the same as `gvm list griffon`
`gvm v groovy` is the same as `gvm version groovy`

And:

`gvm grails 2.1.2` the same as `gvm use grails 2.1.2`

That's quite cool, am I right? :)

Another change that would be nice would be to also work if the command and candidate are given in the wrong order -- so if I type `gvm vertx list` it automatically corrects for `gvm list vertx`.

I'm willing to implement this -- with the proper generic treatment for the candidates -- if you guys are willing to upstream this sort of changes. :)

Thanks!
Elias
