### PR TITLE
Fix candidates is empty on tmux

### DIFF
--- a/src/main/bash/gvm-init.sh
+++ b/src/main/bash/gvm-init.sh
@@ -36,6 +36,14 @@ function gvm_source_modules {
 	unset f
 }
 
+function gvm_set_candidates {
+    # Set the candidate array
+    OLD_IFS="$IFS"
+    IFS=","
+    GVM_CANDIDATES=(${GVM_CANDIDATES_CSV})
+    IFS="$OLD_IFS"
+}
+
 # OS specific support (must be 'true' or 'false').
 cygwin=false;
 darwin=false;
@@ -77,6 +85,7 @@ OFFLINE_MESSAGE="This command is not available in offline mode."
 
 # initialise once only
 if [[ "${GVM_INIT}" == "true" ]]; then
+    gvm_set_candidates
 	gvm_source_modules
 	return
 fi
@@ -126,15 +135,14 @@ else
 	echo "$GVM_CANDIDATES_CSV" > "${GVM_DIR}/var/candidates"
 fi
 
+export GVM_CANDIDATES_CSV
+
 # convert csv to array
 if [[ -n $(echo "$SHELL" | grep 'zsh') ]]; then
 	setopt shwordsplit
 fi
 
-OLD_IFS="$IFS"
-IFS=","
-GVM_CANDIDATES=(${GVM_CANDIDATES_CSV})
-IFS="$OLD_IFS"
+gvm_set_candidates
 
 # Build _HOME environment variables and prefix them all to PATH
 


### PR DESCRIPTION
After I updated GVM to 1.3.0, candidates have been empty on tmux.
- zsh 5.0.2 (x86_64-apple-darwin12.2.0)
- tmux 1.8

On tmux:

``` sh
% gvm help
...

   candidate  :
   version    :  where optional, defaults to latest stable if not provided

eg: gvm install groovy
```

``` sh
% gvm list groovy

Stop! groovy is not a valid candidate.
```

``` sh
% echo "GVM_CANDIDATES: $GVM_CANDIDATES"
GVM_CANDIDATES: 
```

``` sh
% echo "GVM_CANDIDATES_CSV: $GVM_CANDIDATES_CSV"
GVM_CANDIDATES_CSV: 
```

``` sh
% cat ~/.gvm/var/candidates
gradle,grails,griffon,groovy,groovyserv,lazybones,vertx
```

I changed `GVM_CANDIDATES_CSV` to export.
But, `GVM_CANDIDATES` can't export because it is array.
So, I extract the function from setting the array, and call it even if gvm has been initialized.
