### PR TITLE
persist offline mode between sessions

### DIFF
--- a/src/main/bash/gvm-init.sh
+++ b/src/main/bash/gvm-init.sh
@@ -27,6 +27,10 @@ if [ -z "${GVM_DIR}" ]; then
 	export GVM_DIR="$HOME/.gvm"
 fi
 
+if [ -e "${GVM_DIR}/GVM_FORCE_OFFLINE" ]; then
+	GVM_FORCE_OFFLINE="true"
+fi
+
 function gvm_source_modules {
 	# Source gvm module scripts.
 	for f in $(find "${GVM_DIR}/src" -type f -name 'gvm-*'); do

--- a/src/main/bash/gvm-offline.sh
+++ b/src/main/bash/gvm-offline.sh
@@ -18,10 +18,12 @@
 
 function __gvmtool_offline {
 	if [[ "$1" == "enable" ]]; then
+		touch "${GVM_DIR}/GVM_FORCE_OFFLINE" || return 1
 		GVM_FORCE_OFFLINE="true"
 		echo "Forced offline mode enabled."
 	fi
 	if [[ "$1" == "disable" ]]; then
+		rm -f "${GVM_DIR}/GVM_FORCE_OFFLINE" || return 1
 		GVM_FORCE_OFFLINE="false"
 		GVM_ONLINE="true"
 		echo "Online mode re-enabled!"


### PR DESCRIPTION
touch a file in GVM_DIR named after the environment variable
GVM_FORCE_OFFLINE when `gvm offline enable` is called. If this file
exists when a new shell is started, the GVM_FORCE_OFFLINE variable will
be set to "true" before any network calls are made.
