### PR TITLE
Handling GVM_DIR path with spaces when running source command.

### DIFF
--- a/src/main/bash/gvm-init.sh
+++ b/src/main/bash/gvm-init.sh
@@ -29,9 +29,9 @@ fi
 
 function gvm_source_modules {
 	# Source gvm module scripts.
-	for f in $(find "${GVM_DIR}/src" -type f -name 'gvm-*'); do
-		source "${f}"
-	done
+        for f in $(find "${GVM_DIR}/src" -type f -name 'gvm-*' -exec basename {} \;); do
+                source "${GVM_DIR}/src/${f}"
+        done
 
 	# Source extension files prefixed with 'gvm-' and found in the ext/ folder
 	# Use this if extensions are written with the functional approach and want


### PR DESCRIPTION
After being unable to install gvm on a path that contained spaces I've modded just enought of the bash script to handle the installation using the value from GVM_DIR when executing source command.

Ran test without problems:

./gradlew --stacktrace
Environment is set to: local
:clean
:prepareTestScripts
:prepareScripts
:prepareServer
:prepareTemplates
:assembleArchive
:compileJava UP-TO-DATE
:compileGroovy
:processResources UP-TO-DATE
:classes
:compileTestJava UP-TO-DATE
:compileTestGroovy
:processTestResources
:testClasses
:test

BUILD SUCCESSFUL

Total time: 40.422 secs
