### PR TITLE
Fixed an issue with using the command "gvm current"

### DIFF
--- a/src/main/bash/gvm-current.sh
+++ b/src/main/bash/gvm-current.sh
@@ -46,7 +46,7 @@ function __gvmtool_current {
 		fi
 	else
 		INSTALLED_COUNT=0
-		for (( i=0; i <= ${GVM_CANDIDATE_COUNT}; i++ )); do
+		for (( i=0, numCandidates=${#GVM_CANDIDATES[@]}; i <= numCandidates; i++ )); do
 			# Eliminate empty entries due to incompatibility
 			if [[ -n ${GVM_CANDIDATES[${i}]} ]]; then
 				__gvmtool_determine_current_version "${GVM_CANDIDATES[${i}]}"


### PR DESCRIPTION
Fixed an issue with using the command "gvm current"; I was getting an error regarding bad arithmetic. It looked like the cause was an uninitialized GVM_CANDIDATE_COUNT var.
