### PR TITLE
Fix for gvm-init.sh error on GNU bash 4.2.45

### DIFF
--- a/src/main/bash/gvm-init.sh
+++ b/src/main/bash/gvm-init.sh
@@ -117,7 +117,6 @@ fi
 if [[ "${GVM_INIT}" == "true" ]]; then
     gvm_set_candidates
 	gvm_source_modules
-	return
 fi
 
 # Attempt to set JAVA_HOME if it's not already set.


### PR DESCRIPTION
removed invalid return statement causing gvm-init.sh to abort on GNU bash, version 4.2.45(1)-release (x86_64-pc-linux-gnu)

```
bash -x .gvim/bin/gvim-init.sh
...
.gvm/bin/gvm-init.sh: line 120: return: can only `return' from a function or sourced script
```
