### PR TITLE
allow specifying curl options in ~/.gvm/etc/curlrc

### DIFF
--- a/src/main/bash/gvm-common.sh
+++ b/src/main/bash/gvm-common.sh
@@ -55,10 +55,10 @@ function __gvmtool_determine_version {
 
 	elif [[ "${GVM_AVAILABLE}" == "true" && -z "$1" ]]; then
 		VERSION_VALID='valid'
-		VERSION=$(curl -s "${GVM_SERVICE}/candidates/${CANDIDATE}/default")
+		VERSION=$(curl -K "${GVM_CURLRC}" -s "${GVM_SERVICE}/candidates/${CANDIDATE}/default")
 
 	else
-		VERSION_VALID=$(curl -s "${GVM_SERVICE}/candidates/${CANDIDATE}/$1")
+		VERSION_VALID=$(curl -K "${GVM_CURLRC}" -s "${GVM_SERVICE}/candidates/${CANDIDATE}/$1")
 		if [[ "${VERSION_VALID}" == 'valid' || ( "${VERSION_VALID}" == 'invalid' && -n "$2" ) ]]; then
 			VERSION="$1"
 

--- a/src/main/bash/gvm-list.sh
+++ b/src/main/bash/gvm-list.sh
@@ -65,7 +65,7 @@ function __gvmtool_list {
 	if [[ "${GVM_AVAILABLE}" == "false" ]]; then
 		__gvmtool_offline_list
 	else
-		FRAGMENT=$(curl -s "${GVM_SERVICE}/candidates/${CANDIDATE}/list?platform=${GVM_PLATFORM}&current=${CURRENT}&installed=${CSV}")
+		FRAGMENT=$(curl -K "${GVM_CURLRC}" -s "${GVM_SERVICE}/candidates/${CANDIDATE}/list?platform=${GVM_PLATFORM}&current=${CURRENT}&installed=${CSV}")
 		echo "${FRAGMENT}"
 		unset FRAGMENT
 	fi

--- a/src/main/bash/gvm-main.sh
+++ b/src/main/bash/gvm-main.sh
@@ -54,7 +54,7 @@ function gvm {
 	if [[ "$GVM_FORCE_OFFLINE" == "true" || ( "$COMMAND" == "offline" && "$QUALIFIER" == "enable" ) ]]; then
 		BROADCAST_LIVE=""
 	else
-		BROADCAST_LIVE=$(curl -s "${GVM_SERVICE}/broadcast/${GVM_VERSION}")
+		BROADCAST_LIVE=$(curl -K "${GVM_CURLRC}" -s "${GVM_SERVICE}/broadcast/${GVM_VERSION}")
 		gvm_offline_on_redirect "$BROADCAST_LIVE"
 		if [[ "$GVM_FORCE_OFFLINE" == 'true' ]]; then BROADCAST_LIVE=""; fi
 	fi

--- a/src/main/bash/gvm-selfupdate.sh
+++ b/src/main/bash/gvm-selfupdate.sh
@@ -32,6 +32,6 @@ function __gvmtool_selfupdate {
 		echo "No update available at this time."
 
 	else
-		curl -s "${GVM_SERVICE}/selfupdate" | bash
+		curl -K "${GVM_CURLRC}" -s "${GVM_SERVICE}/selfupdate" | bash
 	fi
 }

--- a/src/main/bash/install.sh
+++ b/src/main/bash/install.sh
@@ -175,7 +175,7 @@ mkdir -p "${gvm_var_folder}"
 
 echo "Create candidate directories..."
 
-GVM_CANDIDATES_CSV=$(curl -s "${GVM_SERVICE}/candidates")
+GVM_CANDIDATES_CSV=$(curl -K "${GVM_CURLRC}" -s "${GVM_SERVICE}/candidates")
 echo "$GVM_CANDIDATES_CSV" > "${GVM_DIR}/var/candidates"
 
 echo "$GVM_VERSION" > "${GVM_DIR}/var/version"
@@ -203,7 +203,7 @@ echo "gvm_suggestive_selfupdate=true" >> "${gvm_config_file}"
 echo "gvm_auto_selfupdate=false" >> "${gvm_config_file}"
 
 echo "Download script archive..."
-curl -s "${GVM_SERVICE}/res?platform=${gvm_platform}&purpose=install" > "${gvm_zip_file}"
+curl -K "${GVM_CURLRC}" -s "${GVM_SERVICE}/res?platform=${gvm_platform}&purpose=install" > "${gvm_zip_file}"
 
 echo "Extract script archive..."
 if [[ "${cygwin}" == 'true' ]]; then

--- a/src/main/bash/selfupdate.sh
+++ b/src/main/bash/selfupdate.sh
@@ -67,7 +67,7 @@ mkdir -p "${GVM_DIR}/var"
 mkdir -p "${GVM_DIR}/tmp"
 
 # prepare candidates
-GVM_CANDIDATES_CSV=$(curl -s "${GVM_SERVICE}/candidates")
+GVM_CANDIDATES_CSV=$(curl -K "${GVM_CURLRC}" -s "${GVM_SERVICE}/candidates")
 echo "$GVM_CANDIDATES_CSV" > "${GVM_DIR}/var/candidates"
 
 # drop version token
@@ -111,7 +111,7 @@ if [[ -z $(cat ${gvm_config_file} | grep 'gvm_auto_selfupdate') ]]; then
 fi
 
 gvm_echo_debug "Download new scripts to: ${gvm_tmp_zip}"
-curl -s "${GVM_SERVICE}/res?platform=${gvm_platform}&purpose=selfupdate" > "${gvm_tmp_zip}"
+curl -K "${GVM_CURLRC}" -s "${GVM_SERVICE}/res?platform=${gvm_platform}&purpose=selfupdate" > "${gvm_tmp_zip}"
 
 gvm_echo_debug "Extract script archive..."
 gvm_echo_debug "Unziping scripts to: ${gvm_stage_folder}"


### PR DESCRIPTION
- use "connect-timeout=5" as default content of file
- prevents stalling and makes the automatic switching to offline mode work when api.gvmtool.net is down
