### PR TITLE
unset i at the end of gvm-init.sh to avoid error in zsh

### DIFF
--- a/src/main/bash/gvm-init.sh
+++ b/src/main/bash/gvm-init.sh
@@ -222,5 +222,5 @@ if [[ "$GVM_REMOTE_VERSION" != "$GVM_VERSION" ]]; then
     fi
 fi
 
-
+unset i
 export GVM_INIT="true"


### PR DESCRIPTION
Added "unset i" near the end of the file to not expose the variable to the original shell. When using zsh, that had caused strange behaviour when (re-)using a variable called "i":

``` Shell
$ for i in *.pdf; do echo $i ; done
zsh: bad floating point constant
```

See: https://github.com/gvmtool/gvm/issues/231
