### PR TITLE
added exit status steps to gvm install feature (fixes #223)

### DIFF
--- a/src/main/bash/gvm-install.sh
+++ b/src/main/bash/gvm-install.sh
@@ -56,7 +56,7 @@ function __gvmtool_install {
 	if [[ -d "${GVM_DIR}/${CANDIDATE}/${VERSION}" || -h "${GVM_DIR}/${CANDIDATE}/${VERSION}" ]]; then
 		echo ""
 		echo "Stop! ${CANDIDATE} ${VERSION} is already installed."
-		return 1
+		return 0
 	fi
 
 	if [[ ${VERSION_VALID} == 'valid' ]]; then
@@ -71,7 +71,7 @@ function __gvmtool_install {
 			echo "Setting ${CANDIDATE} ${VERSION} as default."
 			__gvmtool_link_candidate_version "${CANDIDATE}" "${VERSION}"
 		fi
-		return 1
+		return 0
 
 	elif [[ "${VERSION_VALID}" == 'invalid' && -n "${LOCAL_FOLDER}" ]]; then
 		__gvmtool_install_local_version "${CANDIDATE}" "${VERSION}" "${LOCAL_FOLDER}" || return 1

--- a/src/test/cucumber/gvm/install_candidate.feature
+++ b/src/test/cucumber/gvm/install_candidate.feature
@@ -9,20 +9,24 @@ Feature: Install Candidate
     When I enter "gvm install grails" and answer "Y"
     Then I see "Done installing!"
     Then the candidate "grails" version "2.1.0" is installed
+    And the exit status is zero
 
   Scenario: Install a specific Candidate
     When I enter "gvm install grails 1.3.9" and answer "Y"
     Then I see "Done installing!"
     Then the candidate "grails" version "1.3.9" is installed
+    And the exit status is zero
 
   Scenario: Install a Candidate version that does not exist
     When I enter "gvm install grails 1.4.4"
     Then I see "Stop! 1.4.4 is not a valid grails version."
+    And the exit status is non-zero
 
   Scenario: Install a Candidate version that is already installed
     Given the candidate "grails" version "1.3.9" is already installed and default
     When I enter "gvm install grails 1.3.9"
     Then I see "Stop! grails 1.3.9 is already installed."
+    And the exit status is zero
 
   Scenario: Install a candidate and select to use it
     When I enter "gvm install grails 2.1.0" and answer "Y"
@@ -31,6 +35,7 @@ Feature: Install Candidate
     And I see "Do you want grails 2.1.0 to be set as default? (Y/n)"
     And I see "Setting grails 2.1.0 as default."
     Then the candidate "grails" version "2.1.0" should be the default
+    And the exit status is zero
 
   Scenario: Install a candidate and select to use it automatically
     And I have configured "gvm_auto_answer" to "true"
@@ -39,6 +44,7 @@ Feature: Install Candidate
     And I see "Done installing!"
     And I see "Setting grails 2.1.0 as default."
     Then the candidate "grails" version "2.1.0" should be the default
+    And the exit status is zero
 
   Scenario: Install a candidate and do not select to use it
     When I enter "gvm install grails 2.1.0" and answer "n"
@@ -47,12 +53,14 @@ Feature: Install Candidate
     And I see "Do you want grails 2.1.0 to be set as default? (Y/n)"
     And I do not see "Setting grails 2.1.0 as default."
     Then the candidate "grails" version "2.1.0" should not be the default
+    And the exit status is zero
 
   #revisit to redownload automatically
   Scenario: Abort installation on download of a corrupt Candidate archive
     Given the archive for candidate "grails" version "1.3.6" is corrupt
     When I enter "gvm install grails 1.3.6"
     Then I see "Stop! The archive was corrupt and has been removed! Please try installing again."
+    And the exit status is non-zero
     And the candidate "grails" version "1.3.6" is not installed
     And the archive for candidate "grails" version "1.3.6" is removed
 	

--- a/src/test/steps/gvm/command_line_interop_steps.groovy
+++ b/src/test/steps/gvm/command_line_interop_steps.groovy
@@ -24,8 +24,12 @@ And(~'^I see only \"([^\"]*)\"$') { String output ->
     assert result?.replaceAll("\\n", "") == output
 }
 
-And(~'^the exit value is \"([^\"]*)\"$') { int exitValue ->
-    assert bash.status == exitValue
+And(~'^the exit status is zero$') {->
+    assert bash.status == 0
+}
+
+And(~'^the exit status is non-zero$') {->
+    assert bash.status != 0
 }
 
 And(~'^I see the current gvm version$') {->


### PR DESCRIPTION
i came across this issue when trying to automate the gvm setup using salt.

if a candidate is already installed, the exit status is interpreted has a failure. the same happens if you try to install a candidate and automate the 'set as default' answer.

i've updated the gvm install feature with what i believe it should be the common sense exit status (but then again, i might be missing the big picture). anyway, the stakeholders for the gvm project are definitely technical people, so i think the exit status should be part of the specs.

this should fix #223
