### PR TITLE
Fixes download.sh: Minor output clean-up

### DIFF
--- a/contrib/download.sh
+++ b/contrib/download.sh
@@ -16,7 +16,9 @@ ARCHIVE="${ARCHIVE_DIR}/${CANDIDATE}-${VERSION}.zip"
 DESTINATION_DIR="$BASE_DIR/$CANDIDATE-$VERSION"
 
 function download_archive {
-    curl -# -L "${API}/download/${CANDIDATE}/${VERSION}?platform=$(uname)" > "$ARCHIVE"
+    echo -n "Downloading $CANDIDATE-$VERSION... "
+    curl -s -L "${API}/download/${CANDIDATE}/${VERSION}?platform=$(uname)" > "$ARCHIVE"
+    [ $? == 0 ] && echo "DONE" || echo " -- error downloading $CANDIDATE-$VERSION"
 }
 
 if [ -d "$TMP_DIR" ]; then
@@ -42,7 +44,6 @@ if [[ -f "$ARCHIVE" ]]; then
         download_archive
     fi
 else
-    echo "Downloading archive..."
     download_archive
 fi
 


### PR DESCRIPTION
Hi, Marco!
So, I've changed the script to clean the output a little bit, because the curl progress bar was filling the log output with:

```
....
#########################################################                 79,6%
#########################################################                 79,6%
#########################################################                 79,6%
#########################################################                 79,6%
#########################################################                 79,7%
#########################################################                 79,7%
.... (thousands of lines like these, from 0 to 100)
```

This changes the download_archive function to use a silent curl and print some basic information about the download status.
