### PR TITLE
Add an environment variable to overwrite gvm_auto_answer.

### DIFF
--- a/src/main/bash/gvm-main.sh
+++ b/src/main/bash/gvm-main.sh
@@ -81,6 +81,11 @@ function gvm {
 		source "${GVM_DIR}/etc/config"
 	fi
 
+  # Overwrite gvm_auto_answer from environment variable
+  if [[ "$GVM_AUTO_ANSWER" == "true" ]]; then
+    gvm_auto_answer=true
+  fi
+
  	# no command provided
 	if [[ -z "$COMMAND" ]]; then
 		__gvmtool_help

--- a/src/test/cucumber/gvm/install_candidate.feature
+++ b/src/test/cucumber/gvm/install_candidate.feature
@@ -46,6 +46,13 @@ Feature: Install Candidate
     Then the candidate "grails" version "2.1.0" should be the default
     #And the exit status is zero
 
+  Scenario: Install a candidate and select to use it using an environment variable
+    When I enter "GVM_AUTO_ANSWER=true gvm install grails 2.1.0"
+    Then the candidate "grails" version "2.1.0" is installed
+    And I see "Done installing!"
+    And I see "Setting grails 2.1.0 as default."
+    Then the candidate "grails" version "2.1.0" should be the default
+
   Scenario: Install a candidate and do not select to use it
     When I enter "gvm install grails 2.1.0" and answer "n"
     Then the candidate "grails" version "2.1.0" is installed
@@ -63,4 +70,4 @@ Feature: Install Candidate
     #And the exit status is non-zero
     And the candidate "grails" version "1.3.6" is not installed
     And the archive for candidate "grails" version "1.3.6" is removed
-	
+


### PR DESCRIPTION
When doing automated tasks with GVM we felt we needed to configure gvm_auto_answer in a faster way. Writing a file adds the complication of returning the file to whatever state it was before, which is not really a concern of the automation.

The ideal solution would probably be a command line switch, but this also solves it for us.
