### PR TITLE
Unset IFS before looping over modules.

### DIFF
--- a/src/main/bash/gvm-init.sh
+++ b/src/main/bash/gvm-init.sh
@@ -37,6 +37,7 @@ fi
 
 function gvm_source_modules {
 	# Source gvm module scripts.
+	unset IFS
     for f in $(find "${GVM_DIR}/src" -type f -name 'gvm-*' -exec basename {} \;); do
         source "${GVM_DIR}/src/${f}"
     done


### PR DESCRIPTION
Out of the box on my machine, IFS was set incorrectly when looping over modules, causing:

```
$ source gvm-init.sh
bash: /Users/ddcapotter/.gvm/src/gvm-broadcast.sh
gvm-common.sh
gvm-current.sh
gvm-default.sh
gvm-flush.sh
gvm-help.sh
gvm-install.sh
gvm-list.sh
gvm-main.sh
gvm-offline.sh
gvm-selfupdate.sh
gvm-uninstall.sh
gvm-use.sh
gvm-version.sh: No such file or directory
```

A simple `unset IFS` will cause the loop to delimitate on newline as expected.

Bash version: 4.3.30(1)-release
MacOSX version: 10.9.5
