### PR TITLE
follow symlinks in __gvmtool_build_version_csv / find

### DIFF
--- a/config.groovy
+++ b/config.groovy
@@ -1,5 +1,5 @@
 vertxVersion = '1.3.1.final'
-gvmVersion = '1.0.0-SNAPSHOT'
+gvmVersion = '2.2.0'
 environments {
 	local {
 		gvmService = 'http://localhost:8080'

--- a/src/main/bash/gvm-list.sh
+++ b/src/main/bash/gvm-list.sh
@@ -19,7 +19,7 @@
 function __gvmtool_build_version_csv {
 	CANDIDATE="$1"
 	CSV=""
-	for version in $(find "${GVM_DIR}/${CANDIDATE}" -maxdepth 1 -mindepth 1 -exec basename '{}' \; | sort); do
+	for version in $(find -L "${GVM_DIR}/${CANDIDATE}" -maxdepth 1 -mindepth 1 -exec basename '{}' \; | sort); do
 		if [[ "${version}" != 'current' ]]; then
 			CSV="${version},${CSV}"
 		fi


### PR DESCRIPTION
`gvm list grails` fails (does not show any local installed versions, except current) if ${GVM_DIR}/grails is a symlink. This patch adds **-L** option to find.