### PR TITLE
Increase curl timeout parameters on sdkman-init.sh

### DIFF
--- a/src/main/bash/sdkman-init.sh
+++ b/src/main/bash/sdkman-init.sh
@@ -148,13 +148,13 @@ if [[ ! -f "${SDKMAN_DIR}/var/delay_upgrade" ]]; then
 	touch "${SDKMAN_DIR}/var/delay_upgrade"
 fi
 
-# determine if up to date
+# determine if up to date each 24 hours (60*60*24)
 SDKMAN_VERSION_TOKEN="${SDKMAN_DIR}/var/version"
 if [[ -f "$SDKMAN_VERSION_TOKEN" && -z "$(find "$SDKMAN_VERSION_TOKEN" -mmin +$((60*24)))" ]]; then
     SDKMAN_REMOTE_VERSION=$(cat "$SDKMAN_VERSION_TOKEN")
 
 else
-    SDKMAN_REMOTE_VERSION=$(curl -s "${SDKMAN_SERVICE}/app/version" --connect-timeout 1 --max-time 1)
+    SDKMAN_REMOTE_VERSION=$(curl -s "${SDKMAN_SERVICE}/app/version" --connect-timeout 15 --max-time 15)
     sdkman_force_offline_on_proxy "$SDKMAN_REMOTE_VERSION"
     if [[ -z "$SDKMAN_REMOTE_VERSION" || "$SDKMAN_FORCE_OFFLINE" == 'true' ]]; then
         SDKMAN_REMOTE_VERSION="$SDKMAN_VERSION"

--- a/src/main/bash/sdkman-init.sh
+++ b/src/main/bash/sdkman-init.sh
@@ -148,7 +148,7 @@ if [[ ! -f "${SDKMAN_DIR}/var/delay_upgrade" ]]; then
 	touch "${SDKMAN_DIR}/var/delay_upgrade"
 fi
 
-# determine if up to date each 24 hours (60*60*24)
+# determine if up to date
 SDKMAN_VERSION_TOKEN="${SDKMAN_DIR}/var/version"
 if [[ -f "$SDKMAN_VERSION_TOKEN" && -z "$(find "$SDKMAN_VERSION_TOKEN" -mmin +$((60*24)))" ]]; then
     SDKMAN_REMOTE_VERSION=$(cat "$SDKMAN_VERSION_TOKEN")


### PR DESCRIPTION
Increase curl *--connect-timeout* and *--max-time* parameters to a bigger value (15/20 seconds instead of 1 second) to restore acceptable startup time of the bash shell.

On my system (ubuntu 14.04.03 x86_64 in Italy) dsn resolution of "api.sdkman.it" took a longer time of the expected behaviour (~8 seconds, view Note 1). The curl utility wait entirely this time despite the --max-time 1 option.

This lead every shell spawned on the system to hangs until curl return. Note that curl fails without actually download anything (the file ~/.sdkman/var/version is not written), so the behaviour is repeated everytime.

* Note 1
```bash
$ time curl "http://api.sdkman.io/app/version" --connect-timeout 1 --max-time 1
curl: (28) Resolving timed out after 1510 milliseconds

real    0m8.076s
user    0m0.004s
sys     0m0.011s
```