### PR TITLE
Allow other pagers besides "less" to be used.

### DIFF
--- a/src/main/bash/sdkman-list.sh
+++ b/src/main/bash/sdkman-list.sh
@@ -68,7 +68,7 @@ function __sdkman_list {
 }
 
 function __sdkman_list_candidates {
-    echo "$(curl -s "${SDKMAN_SERVICE}/candidates/list")" | less
+    echo "$(curl -s "${SDKMAN_SERVICE}/candidates/list")" | ${PAGER-less}
 }
 
 function __sdkman_list_versions {


### PR DESCRIPTION
A simple change to respect the PAGER environment variable. This allows other pagers besides "less" to be used.  Additionally, it allows paging to be turned off entirely by setting PAGER to cat.
If PAGER is unset, it defaults to less, so the default behavior is unchanged.