### PR TITLE
Fix "find: xxx: No such file or directory" error when using 'outdated' command

### DIFF
--- a/src/main/bash/sdkman-outdated.sh
+++ b/src/main/bash/sdkman-outdated.sh
@@ -5,7 +5,7 @@ function __sdkman_determine_outdated_version {
     candidate="$1"
 
     # Resolve local versions
-    local_versions="$(echo $(find "${SDKMAN_CANDIDATES_DIR}/${candidate}" -maxdepth 1 -mindepth 1 -type d -exec basename '{}' \;) | sed -e "s/ /, /g" )"
+    local_versions="$(echo $(find "${SDKMAN_CANDIDATES_DIR}/${candidate}" -maxdepth 1 -mindepth 1 -type d -exec basename '{}' \; 2>/dev/null) | sed -e "s/ /, /g" )"
     if [ ${#local_versions} -eq 0 ]; then
         return 1
     fi


### PR DESCRIPTION
Before, there were empty candidates directories even if it's not installed. Now, there are no directories of candidates which isn't installed. So you should fix it.

```
$ sdk outdated
find: /Users/nobeans/.sdkman/candidates/asciidoctorj: No such file or directory
find: /Users/nobeans/.sdkman/candidates/crash: No such file or directory
find: /Users/nobeans/.sdkman/candidates/griffon: No such file or directory
```