### PR TITLE
Fix "not valid in thes context" when working with Cygwin

### DIFF
--- a/src/main/bash/sdkman-utils.sh
+++ b/src/main/bash/sdkman-utils.sh
@@ -18,7 +18,7 @@
 
 function __sdkman_path_contains {
     local candidate="$1"
-    local exists=$(echo "$PATH" | grep "$candidate")
+    local exists="$(echo "$PATH" | grep "$candidate")"
     if [[ -n "$exists" ]]; then
         SDKMAN_CANDIDATE_IN_PATH='true'
     else


### PR DESCRIPTION
I execute sdk command(Ex: "sdk list groovy"). But it could not run.
The shell had an error.

```
__sdkman_path_contains:local:2: not valid in this context: (x86)/MacType:/cygdrive/c/ProgramData/Oracle/Java/javapath:/cygdrive/c/Program
Files=''
Files=''
Files=''
Files=''
Files=''
Management=''
Engine=''
Files=''
Management=''
Engine=''
Files=''
Management=''
Engine=''
Files=''
Files=''
SQL=''
Files=''
Files=''
```

So I fixed this bug.
It occurred because there is no double quotes in the path. Cygwin path is included windows system path("Program Files","Program Files(x86)").