### PR TITLE
Updates to bash scripts for Windows compatiblity on both Cygwin* and MINGW*

### DIFF
--- a/src/main/bash/sdkman-init.sh
+++ b/src/main/bash/sdkman-init.sh
@@ -153,7 +153,7 @@ for (( i=0; i <= ${#SDKMAN_CANDIDATES[*]}; i++ )); do
 	# Eliminate empty entries due to incompatibility
 	CANDIDATE_NAME="${SDKMAN_CANDIDATES[${i}]}"
 	CANDIDATE_DIR="${SDKMAN_CANDIDATES_DIR}/${CANDIDATE_NAME}/current"
-	if [[ -n "$CANDIDATE_NAME" && -h "$CANDIDATE_DIR" ]]; then
+	if [[ -n "$CANDIDATE_NAME" && ( -h "$CANDIDATE_DIR" || -d "${CANDIDATE_DIR}" ) ]]; then
 		__sdkman_export_candidate_home "$CANDIDATE_NAME" "$CANDIDATE_DIR"
 		__sdkman_prepend_candidate_to_path "$CANDIDATE_DIR"
 	fi

--- a/src/main/bash/sdkman-path-helpers.sh
+++ b/src/main/bash/sdkman-path-helpers.sh
@@ -81,8 +81,8 @@ function __sdkman_link_candidate_version {
 	version="$2"
 
 	# Change the 'current' symlink for the candidate, hence affecting all shells.
-	if [ -L "${SDKMAN_CANDIDATES_DIR}/${candidate}/current" ]; then
-		unlink "${SDKMAN_CANDIDATES_DIR}/${candidate}/current"
+	if [[ -h "${SDKMAN_CANDIDATES_DIR}/${candidate}/current" || -d "${SDKMAN_CANDIDATES_DIR}/${candidate}/current" ]]; then
+		rm -rf "${SDKMAN_CANDIDATES_DIR}/${candidate}/current"
 	fi
 	ln -s "${SDKMAN_CANDIDATES_DIR}/${candidate}/${version}" "${SDKMAN_CANDIDATES_DIR}/${candidate}/current"
 }

--- a/src/main/bash/sdkman-use.sh
+++ b/src/main/bash/sdkman-use.sh
@@ -53,7 +53,7 @@ function __sdk_use {
 		export PATH=$(echo $PATH | sed -r "s!${SDKMAN_CANDIDATES_DIR}/${candidate}/([^/]+)!${SDKMAN_CANDIDATES_DIR}/${candidate}/${VERSION}!g")
 	fi
 
-	if [[ ! -h "${SDKMAN_CANDIDATES_DIR}/${candidate}/current" ]]; then
+	if [[ ! ( -h "${SDKMAN_CANDIDATES_DIR}/${candidate}/current" || -d "${SDKMAN_CANDIDATES_DIR}/${candidate}/current" ) ]]; then
 	    echo "Setting ${candidate} version ${VERSION} as default."
 		__sdkman_link_candidate_version "$candidate" "$VERSION"
 	fi


### PR DESCRIPTION
The updates that I have applied relate to how both Cygwin and MINGW both handle symlinks. On a Windows system, symlinks are supported until later versions of Windows (Vista and after), however these symlinks aren't the same as a native Linux symlink in that all of the metadata persists, so instead bash emulators such as Cygwin and MINGW have `ln` create a copy of the folder being targeted instead at the location where the symlink would have been placed. These modifications make the necessary adjustments to allow the deletion and checking for the existance of a folder or a symlink, thus allowing native use of the sdkman library on Windows in either Cygwin and MINGW correctly.