### PR TITLE
fixing similar issue to #232 `unset i`

### DIFF
--- a/src/main/bash/sdkman-init.sh
+++ b/src/main/bash/sdkman-init.sh
@@ -183,6 +183,7 @@ for (( i=0; i <= ${#SDKMAN_CANDIDATES[*]}; i++ )); do
 	unset CANDIDATE_NAME
 	unset CANDIDATE_DIR
 done
+unset i
 export PATH
 
 alias gvm="sdk"


### PR DESCRIPTION
the missing `unset i` causes issues in zsh if you use the variable `i` in your
own code outside sdkman