### PR TITLE
FEATURE #388 - Add test for this behaviour: Install script should install init script at bin dir.

### DIFF
--- a/src/test/groovy/sdkman/specs/BootstrapSpec.groovy
+++ b/src/test/groovy/sdkman/specs/BootstrapSpec.groovy
@@ -5,7 +5,7 @@ import sdkman.stubs.CurlStub
 import sdkman.env.SdkManBashEnvBuilder
 import spock.lang.Specification
 
-import static sdkman.utils.FilesystemUtils.prepareBaseDir
+import static sdkman.utils.FilesystemUtils.prepareSdkmanDir
 
 class BootstrapSpec extends Specification {
 
@@ -18,7 +18,7 @@ class BootstrapSpec extends Specification {
     String versionToken
 
     void setup(){
-        sdkmanBaseDir = prepareBaseDir()
+        sdkmanBaseDir = prepareSdkmanDir()
         sdkmanBaseEnv = sdkmanBaseDir.absolutePath
         bootstrap = "${sdkmanBaseDir.absolutePath}/.sdkman/bin/sdkman-init.sh"
         versionToken = "${sdkmanBaseDir.absolutePath}/.sdkman/var/version"

--- a/src/test/groovy/sdkman/specs/CurrentCommandSpec.groovy
+++ b/src/test/groovy/sdkman/specs/CurrentCommandSpec.groovy
@@ -8,7 +8,7 @@ import spock.lang.Specification
 import java.nio.file.Paths
 
 import static java.nio.file.Files.createSymbolicLink
-import static sdkman.utils.FilesystemUtils.prepareBaseDir
+import static sdkman.utils.FilesystemUtils.prepareSdkmanDir
 
 class CurrentCommandSpec extends Specification {
 
@@ -21,7 +21,7 @@ class CurrentCommandSpec extends Specification {
     String candidatesDir
 
     void setup() {
-        sdkmanBaseDir = prepareBaseDir()
+        sdkmanBaseDir = prepareSdkmanDir()
         sdkmanDotDir = "${sdkmanBaseDir.absolutePath}/.sdkman"
         bootstrap = "${sdkmanDotDir}/bin/sdkman-init.sh"
         candidatesDir = "${sdkmanDotDir}/candidates"

--- a/src/test/groovy/sdkman/specs/InitialisationSpec.groovy
+++ b/src/test/groovy/sdkman/specs/InitialisationSpec.groovy
@@ -8,7 +8,7 @@ import spock.lang.Specification
 import java.nio.file.Files
 import java.nio.file.Paths
 
-import static sdkman.utils.FilesystemUtils.prepareBaseDir
+import static sdkman.utils.FilesystemUtils.prepareSdkmanDir
 
 class InitialisationSpec extends Specification {
 
@@ -24,7 +24,7 @@ class InitialisationSpec extends Specification {
     String candidatesDir
 
     void setup(){
-        sdkmanBaseDir = prepareBaseDir()
+        sdkmanBaseDir = prepareSdkmanDir()
         sdkmanDotDir = "${sdkmanBaseDir.absolutePath}/.sdkman"
         bootstrap = "${sdkmanDotDir}/bin/sdkman-init.sh"
         candidatesDir = "${sdkmanDotDir}/candidates"

--- a/src/test/groovy/sdkman/specs/InstallSpec.groovy
+++ b/src/test/groovy/sdkman/specs/InstallSpec.groovy
@@ -1,0 +1,66 @@
+package sdkman.specs
+
+import sdkman.env.BashEnv
+import sdkman.env.SdkManBashEnvBuilder
+import sdkman.stubs.CurlStub
+import spock.lang.Specification
+
+import static sdkman.utils.FilesystemUtils.defineSdkmanDir
+import static sdkman.utils.FilesystemUtils.defineCounterForSdkmanDir
+import static sdkman.utils.FilesystemUtils.prepareStubInstallDir
+
+class InstallSpec extends Specification {
+    CurlStub curlStub
+    BashEnv bash
+    String home
+    String tmpSdkmanScriptsDir
+    String stubInstallBaseDirPath
+
+    void setup() {
+        String counterForBaseDir = defineCounterForSdkmanDir()
+        File stubInstallBaseDir = prepareStubInstallDir(counterForBaseDir)
+        home = defineSdkmanDir(counterForBaseDir)
+        stubInstallBaseDirPath = "${stubInstallBaseDir.absolutePath}"
+        tmpSdkmanScriptsDir = "${stubInstallBaseDirPath}/tmpSdkmanScripts"
+        curlStub = CurlStub.prepareIn(new File(stubInstallBaseDir, "bin"))
+        bash = SdkManBashEnvBuilder
+                .create(stubInstallBaseDir)
+                .withCurlStub(curlStub)
+                .withShouldEmulateInstallScript(false)
+                .withHome(home)
+                .build()
+    }
+
+    void "should install init script at bin dir"() {
+        given:
+        bash.start()
+        primeDownloadSdkmanEndpoint()
+        bash.execute("bash ${stubInstallBaseDirPath}/install.sh")
+        bash.resetOutput()
+
+        when:
+        bash.execute("ls ${home}/.sdkman/bin")
+
+        then:
+        bash.output.contains("sdkman-init.sh")
+    }
+
+    private def primeDownloadSdkmanEndpoint() {
+        def sdkmanScriptsZip = createSdkmanScriptsZip()
+        curlStub.primeWith("http://localhost:8080/res?platform=${getUname()}&purpose=install", "cat ${sdkmanScriptsZip}").build()
+    }
+
+    private def createSdkmanScriptsZip() {
+        def sdkmanScriptsZipPath = "${stubInstallBaseDirPath}/sdkman-scripts.zip"
+        bash.execute("zip -j ${sdkmanScriptsZipPath} ${tmpSdkmanScriptsDir}/*")
+        bash.execute("rm -rf ${tmpSdkmanScriptsDir}")
+        sdkmanScriptsZipPath
+    }
+
+    private def getUname() {
+        bash.execute('echo $(uname)')
+        def uname = bash.output.trim()
+        bash.resetOutput()
+        uname
+    }
+}

--- a/src/test/groovy/sdkman/utils/FilesystemUtils.groovy
+++ b/src/test/groovy/sdkman/utils/FilesystemUtils.groovy
@@ -21,11 +21,29 @@ class FilesystemUtils {
         currentSymlinkPath ? Files.readSymbolicLink(Paths.get(currentSymlinkPath)).fileName : ""
     }
 
-    static prepareBaseDir() {
-        def counter = "${(Math.random() * 10000).toInteger()}".padLeft(4, "0")
-        def baseDir = "$DEFAULT_BASE_DIR/sdkman-$counter" as File
+    static prepareStubInstallDir(String counter) {
+        def baseDir = "$DEFAULT_BASE_DIR/stub-install-$counter" as File
         baseDir.mkdirs()
         baseDir
+    }
+
+    static prepareSdkmanDir(String counter) {
+        def sdkmanDir = defineSdkmanDir(counter) as File
+        sdkmanDir.mkdirs()
+        sdkmanDir
+    }
+
+    static defineSdkmanDir(String counter) {
+        "$DEFAULT_BASE_DIR/sdkman-$counter"
+    }
+
+    static prepareSdkmanDir() {
+        def counter = defineCounterForSdkmanDir()
+        prepareSdkmanDir(counter)
+    }
+
+    static defineCounterForSdkmanDir() {
+        "${(Math.random() * 10000).toInteger()}".padLeft(4, "0")
     }
 
     static prepareCandidateWithVersionFolder(String baseDir, String candidate, String version) {


### PR DESCRIPTION
The most complex bit about this PR was rethinking SdkManBashEnvBuilder [SMBEB from now on]. SMBEB was assuming that the tests consuming its functionality would be executed after install script. SMBEB was emulating install script behaviour creating folders and placing files around. That's defeating the purpose of testing install script, so a flag called shouldEmulateInstallScript was added.

The concept of base folder was refined too. Previous test didn't care if utilities like stubbed curl lived into .sdkman folder, but this concrete test needs to work in a blank slate, otherwise the script will detect that .sdkman already exists and ther it won't execute itself. For this test the base folder will be something like stub-install-XXX. That folder will contain every stubbed utility needed for the test (curl, install script and sdkman-scripts.zip)

Being able to work with different namespaces living in /tmp folder is really convenient. As install.script is installing sdkman on $HOME, SMBEB is accepting now a new variable for that purpose.