### PR TITLE
FEATURE #388 - First spec for install script.

### DIFF
--- a/src/test/groovy/sdkman/env/CleanBashEnvBuilder.groovy
+++ b/src/test/groovy/sdkman/env/CleanBashEnvBuilder.groovy
@@ -1,0 +1,27 @@
+package sdkman.env
+
+class CleanBashEnvBuilder {
+    private final File baseFolder
+    String httpProxy
+
+    static CleanBashEnvBuilder create(File baseFolder){
+        new CleanBashEnvBuilder(baseFolder)
+    }
+
+    private CleanBashEnvBuilder(File baseFolder){
+        this.baseFolder = baseFolder
+    }
+
+    CleanBashEnvBuilder withHttpProxy(String httpProxy){
+        this.httpProxy = httpProxy
+        this
+    }
+
+    BashEnv build() {
+        def env = [HOME: baseFolder.absolutePath]
+        if(httpProxy) {
+            env.put("http_proxy", httpProxy)
+        }
+        new BashEnv(baseFolder.absolutePath, env)
+    }
+}

--- a/src/test/groovy/sdkman/specs/InstallSpec.groovy
+++ b/src/test/groovy/sdkman/specs/InstallSpec.groovy
@@ -1,22 +1,18 @@
 package sdkman.specs
 
+import java.nio.file.Files
+import java.nio.file.Paths
 import com.github.tomakehurst.wiremock.WireMockServer
 import sdkman.env.BashEnv
 import sdkman.env.CleanBashEnvBuilder
 import sdkman.utils.WireMockServerProvider
 import spock.lang.Specification
 
-import static sdkman.stubs.WebServiceStub.primePlainFileEndpoint
-import static sdkman.stubs.WebServiceStub.primeZipEndpoint
+import static sdkman.stubs.WebServiceStub.primeEndpointWithBinary
 import static sdkman.utils.FilesystemUtils.prepareBaseDir
 
 class InstallSpec extends Specification {
-    final installScriptName = "install.sh"
-    final sdkmanScriptsName = "sdkman-scripts.zip"
     final service = "http://localhost:8080"
-    final testScriptBuildDir = "build/testScripts" as File
-    final distributionsBuildDir = "build/distributions" as File
-    final wiremockStaticFolder = "src/test/resources/__files/" as File
     BashEnv bash
     File sdkmanBaseDir
     WireMockServer wireMockServer
@@ -26,14 +22,9 @@ class InstallSpec extends Specification {
         sdkmanBaseDir = prepareBaseDir()
         bash = CleanBashEnvBuilder.create(sdkmanBaseDir).build()
         bash.start()
-        copyInstallRequiredFilesIntoWiremockFolder()
         wireMockServer = WireMockServerProvider.wireMockServer()
         primeInstallScriptEndpoint()
         primeDownloadSdkmanEndpoint()
-    }
-
-    void cleanup() {
-        removeInstallRequiredFilesFromWiremockFolder()
     }
 
     void "should install init script at bin dir"() {
@@ -48,24 +39,14 @@ class InstallSpec extends Specification {
         bash.output.contains("sdkman-init.sh")
     }
 
-    private def copyInstallRequiredFilesIntoWiremockFolder() {
-        def installScript = "${testScriptBuildDir.absolutePath}/${installScriptName}"
-        def sdkManScriptsZip = "${distributionsBuildDir.absolutePath}/${sdkmanScriptsName}"
-        bash.execute("cp ${installScript} ${wiremockStaticFolder.absolutePath}")
-        bash.execute("cp ${sdkManScriptsZip} ${wiremockStaticFolder.absolutePath}")
-    }
-
-    private def removeInstallRequiredFilesFromWiremockFolder() {
-        bash.execute("rm -rf ${wiremockStaticFolder.absolutePath}/${installScriptName}")
-        bash.execute("rm -rf ${wiremockStaticFolder.absolutePath}/${sdkmanScriptsName}")
-    }
-
     private def primeInstallScriptEndpoint() {
-        primePlainFileEndpoint("/", installScriptName)
+        def binary = Files.readAllBytes(Paths.get("build/testScripts/install.sh"))
+        primeEndpointWithBinary("/", binary)
     }
 
     private def primeDownloadSdkmanEndpoint() {
-        primeZipEndpoint("/res?platform=${getUname()}&purpose=install", sdkmanScriptsName)
+        def binary = Files.readAllBytes(Paths.get("build/distributions/sdkman-scripts.zip"))
+        primeEndpointWithBinary("/res?platform=${getUname()}&purpose=install", binary)
     }
 
     private def getUname() {

--- a/src/test/groovy/sdkman/specs/InstallSpec.groovy
+++ b/src/test/groovy/sdkman/specs/InstallSpec.groovy
@@ -1,0 +1,77 @@
+package sdkman.specs
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import sdkman.env.BashEnv
+import sdkman.env.CleanBashEnvBuilder
+import sdkman.utils.WireMockServerProvider
+import spock.lang.Specification
+
+import static sdkman.stubs.WebServiceStub.primePlainFileEndpoint
+import static sdkman.stubs.WebServiceStub.primeZipEndpoint
+import static sdkman.utils.FilesystemUtils.prepareBaseDir
+
+class InstallSpec extends Specification {
+    final installScriptName = "install.sh"
+    final sdkmanScriptsName = "sdkman-scripts.zip"
+    final service = "http://localhost:8080"
+    final testScriptBuildDir = "build/testScripts" as File
+    final distributionsBuildDir = "build/distributions" as File
+    final wiremockStaticFolder = "src/test/resources/__files/" as File
+    BashEnv bash
+    File sdkmanBaseDir
+    WireMockServer wireMockServer
+
+
+    void setup() {
+        sdkmanBaseDir = prepareBaseDir()
+        bash = CleanBashEnvBuilder.create(sdkmanBaseDir).build()
+        bash.start()
+        copyInstallRequiredFilesIntoWiremockFolder()
+        wireMockServer = WireMockServerProvider.wireMockServer()
+        primeInstallScriptEndpoint()
+        primeDownloadSdkmanEndpoint()
+    }
+
+    void cleanup() {
+        removeInstallRequiredFilesFromWiremockFolder()
+    }
+
+    void "should install init script at bin dir"() {
+        given:
+        bash.execute("curl -s ${service} | bash")
+        bash.resetOutput()
+
+        when:
+        bash.execute("ls ${sdkmanBaseDir.absolutePath}/.sdkman/bin")
+
+        then:
+        bash.output.contains("sdkman-init.sh")
+    }
+
+    private def copyInstallRequiredFilesIntoWiremockFolder() {
+        def installScript = "${testScriptBuildDir.absolutePath}/${installScriptName}"
+        def sdkManScriptsZip = "${distributionsBuildDir.absolutePath}/${sdkmanScriptsName}"
+        bash.execute("cp ${installScript} ${wiremockStaticFolder.absolutePath}")
+        bash.execute("cp ${sdkManScriptsZip} ${wiremockStaticFolder.absolutePath}")
+    }
+
+    private def removeInstallRequiredFilesFromWiremockFolder() {
+        bash.execute("rm -rf ${wiremockStaticFolder.absolutePath}/${installScriptName}")
+        bash.execute("rm -rf ${wiremockStaticFolder.absolutePath}/${sdkmanScriptsName}")
+    }
+
+    private def primeInstallScriptEndpoint() {
+        primePlainFileEndpoint("/", installScriptName)
+    }
+
+    private def primeDownloadSdkmanEndpoint() {
+        primeZipEndpoint("/res?platform=${getUname()}&purpose=install", sdkmanScriptsName)
+    }
+
+    private def getUname() {
+        bash.execute('echo $(uname)')
+        def uname = bash.output.trim()
+        bash.resetOutput()
+        uname
+    }
+}

--- a/src/test/groovy/sdkman/specs/InstallSpec.groovy
+++ b/src/test/groovy/sdkman/specs/InstallSpec.groovy
@@ -9,6 +9,7 @@ import sdkman.utils.WireMockServerProvider
 import spock.lang.Specification
 
 import static sdkman.stubs.WebServiceStub.primeEndpointWithBinary
+import static sdkman.stubs.WebServiceStub.primeEndpointWithString
 import static sdkman.utils.FilesystemUtils.prepareBaseDir
 
 class InstallSpec extends Specification {
@@ -40,8 +41,7 @@ class InstallSpec extends Specification {
     }
 
     private def primeInstallScriptEndpoint() {
-        def binary = Files.readAllBytes(Paths.get("build/testScripts/install.sh"))
-        primeEndpointWithBinary("/", binary)
+        primeEndpointWithString("/", ("build/testScripts/install.sh" as File).text)
     }
 
     private def primeDownloadSdkmanEndpoint() {

--- a/src/test/groovy/sdkman/stubs/WebServiceStub.groovy
+++ b/src/test/groovy/sdkman/stubs/WebServiceStub.groovy
@@ -6,40 +6,40 @@ class WebServiceStub {
 
     static primeEndpoint(String endpoint, String body) {
         stubFor(get(urlEqualTo(endpoint)).willReturn(
-            aResponse()
-                .withStatus(200)
-                .withHeader("Content-Type", "text/plain")
-                .withBody(body)))
+                aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody(body)))
+    }
+
+    static primeEndpointWithBinary(String endpoint, byte[] body) {
+        stubFor(get(urlEqualTo(endpoint)).willReturn(
+                aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody(body)))
     }
 
     static primeDownloadFor(String host, String candidate, String version, String platform) {
         stubFor(get(urlEqualTo("/download/${candidate}/${version}?platform=${platform}")).willReturn(
-            aResponse()
-                .withHeader("Location", "${host}/${candidate}-${version}.zip")
-                .withStatus(302)))
+                aResponse()
+                        .withHeader("Location", "${host}/${candidate}-${version}.zip")
+                        .withStatus(302)))
 
         def binary = "${candidate}-${version}.zip"
-        primeZipEndpoint("/$binary", binary)
+        stubFor(get(urlEqualTo("/$binary")).willReturn(
+                aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/zip")
+                        .withBodyFile(binary)))
     }
 
     static primeSelfupdate() {
-        primePlainFileEndpoint("/selfupdate", "selfupdate.sh")
-    }
-
-    static primeFileEndpoint(String endpoint, String filePath, String contentType) {
-        stubFor(get(urlEqualTo(endpoint)).willReturn(
+        stubFor(get(urlEqualTo("/selfupdate")).willReturn(
                 aResponse()
                         .withStatus(200)
-                        .withHeader("Content-Type", contentType)
-                        .withBodyFile(filePath)))
-    }
-
-    static primeZipEndpoint(String endpoint, String filePath) {
-        primeFileEndpoint(endpoint, filePath, "application/zip")
-    }
-
-    static primePlainFileEndpoint(String endpoint, String filePath) {
-        primeFileEndpoint(endpoint, filePath, "text/plain")
+                        .withHeader("Content-Type", "text/plain")
+                        .withBodyFile("selfupdate.sh")))
     }
 
 }

--- a/src/test/groovy/sdkman/stubs/WebServiceStub.groovy
+++ b/src/test/groovy/sdkman/stubs/WebServiceStub.groovy
@@ -19,19 +19,27 @@ class WebServiceStub {
                 .withStatus(302)))
 
         def binary = "${candidate}-${version}.zip"
-        stubFor(get(urlEqualTo("/$binary")).willReturn(
-            aResponse()
-                .withStatus(200)
-                .withHeader("Content-Type", "application/zip")
-                .withBodyFile(binary)))
+        primeZipEndpoint("/$binary", binary)
     }
 
     static primeSelfupdate() {
-        stubFor(get(urlEqualTo("/selfupdate")).willReturn(
-            aResponse()
-                .withStatus(200)
-                .withHeader("Content-Type", "text/plain")
-                .withBodyFile("selfupdate.sh")))
+        primePlainFileEndpoint("/selfupdate", "selfupdate.sh")
+    }
+
+    static primeFileEndpoint(String endpoint, String filePath, String contentType) {
+        stubFor(get(urlEqualTo(endpoint)).willReturn(
+                aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", contentType)
+                        .withBodyFile(filePath)))
+    }
+
+    static primeZipEndpoint(String endpoint, String filePath) {
+        primeFileEndpoint(endpoint, filePath, "application/zip")
+    }
+
+    static primePlainFileEndpoint(String endpoint, String filePath) {
+        primeFileEndpoint(endpoint, filePath, "text/plain")
     }
 
 }

--- a/src/test/groovy/sdkman/stubs/WebServiceStub.groovy
+++ b/src/test/groovy/sdkman/stubs/WebServiceStub.groovy
@@ -4,7 +4,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*
 
 class WebServiceStub {
 
-    static primeEndpoint(String endpoint, String body) {
+    static primeEndpointWithString(String endpoint, String body) {
         stubFor(get(urlEqualTo(endpoint)).willReturn(
                 aResponse()
                         .withStatus(200)
@@ -16,7 +16,7 @@ class WebServiceStub {
         stubFor(get(urlEqualTo(endpoint)).willReturn(
                 aResponse()
                         .withStatus(200)
-                        .withHeader("Content-Type", "text/plain")
+                        .withHeader("Content-Type", "application/octet-stream")
                         .withBody(body)))
     }
 

--- a/src/test/groovy/sdkman/utils/WireMockServerProvider.groovy
+++ b/src/test/groovy/sdkman/utils/WireMockServerProvider.groovy
@@ -1,0 +1,25 @@
+package sdkman.utils
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
+
+class WireMockServerProvider {
+    static SERVICE_UP_HOST = "localhost"
+    static SERVICE_UP_PORT = 8080
+    static WireMockServer wireMockServer
+
+    static def wireMockServer() {
+        wireMockServer == null ? createWireMockServer() : wireMockServer
+    }
+
+    private static def createWireMockServer() {
+        wireMockServer = new WireMockServer(wireMockConfig().port(SERVICE_UP_PORT))
+        wireMockServer.start()
+        WireMock.configureFor(SERVICE_UP_HOST, SERVICE_UP_PORT)
+        wireMockServer
+    }
+
+
+}

--- a/src/test/groovy/sdkman/utils/WireMockServerProvider.groovy
+++ b/src/test/groovy/sdkman/utils/WireMockServerProvider.groovy
@@ -11,7 +11,7 @@ class WireMockServerProvider {
     static WireMockServer wireMockServer
 
     static def wireMockServer() {
-        wireMockServer == null ? createWireMockServer() : wireMockServer
+        wireMockServer ?: createWireMockServer()
     }
 
     private static def createWireMockServer() {

--- a/src/test/steps/sdkman/broadcast_steps.groovy
+++ b/src/test/steps/sdkman/broadcast_steps.groovy
@@ -1,7 +1,7 @@
 package sdkman
 
 import static cucumber.api.groovy.EN.And
-import static sdkman.stubs.WebServiceStub.primeEndpoint
+import static sdkman.stubs.WebServiceStub.primeEndpointWithString
 
 And(~'^no prior Broadcast was received$') { ->
     broadcastFile.delete()
@@ -9,8 +9,8 @@ And(~'^no prior Broadcast was received$') { ->
 }
 
 And(~'^a new Broadcast "(.*)" with id "(.*)" is available$') { String broadcast, String id ->
-    primeEndpoint("/broadcast/latest/id", id)
-    primeEndpoint("/broadcast/latest", broadcast)
+    primeEndpointWithString("/broadcast/latest/id", id)
+    primeEndpointWithString("/broadcast/latest", broadcast)
 }
 
 And(~'^a prior Broadcast "(.*)" with id "(.*)" was issued$') { String broadcast, String id ->

--- a/src/test/steps/sdkman/env.groovy
+++ b/src/test/steps/sdkman/env.groovy
@@ -3,6 +3,7 @@ package sdkman
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
 import sdkman.utils.UnixUtils
+import sdkman.utils.WireMockServerProvider
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
 import static cucumber.api.groovy.Hooks.After
@@ -47,9 +48,7 @@ initScript = new File(binDir, "sdkman-init.sh")
 bash = null
 
 if(!binding.hasVariable("wireMock")) {
-    wireMock = new WireMockServer(wireMockConfig().port(SERVICE_UP_PORT))
-    wireMock.start()
-    WireMock.configureFor(SERVICE_UP_HOST, SERVICE_UP_PORT)
+    wireMock = WireMockServerProvider.wireMockServer()
 }
 
 Before(){

--- a/src/test/steps/sdkman/initialisation_steps.groovy
+++ b/src/test/steps/sdkman/initialisation_steps.groovy
@@ -4,7 +4,7 @@ import java.util.zip.ZipException
 import java.util.zip.ZipFile
 
 import static cucumber.api.groovy.EN.*
-import static sdkman.stubs.WebServiceStub.primeEndpoint
+import static sdkman.stubs.WebServiceStub.primeEndpointWithString
 import static sdkman.stubs.WebServiceStub.primeSelfupdate
 
 import sdkman.env.SdkManBashEnvBuilder
@@ -33,9 +33,9 @@ And(~'^the archive for candidate "([^"]*)" version "([^"]*)" is removed$') { Str
 }
 
 And(~'^the internet is reachable$') {->
-    primeEndpoint("/broadcast/latest/id", "12345")
-    primeEndpoint("/broadcast/latest", "broadcast message")
-    primeEndpoint("/app/version", sdkmanVersion)
+    primeEndpointWithString("/broadcast/latest/id", "12345")
+    primeEndpointWithString("/broadcast/latest", "broadcast message")
+    primeEndpointWithString("/app/version", sdkmanVersion)
     primeSelfupdate()
 
     forcedOffline = false
@@ -52,7 +52,7 @@ And(~'^the internet is not reachable$') {->
 }
 
 And(~'^offline mode is disabled with reachable internet$') {->
-    primeEndpoint("/broadcast/latest", "This is a LIVE Broadcast!")
+    primeEndpointWithString("/broadcast/latest", "This is a LIVE Broadcast!")
 
     forcedOffline = false
     online = true
@@ -61,7 +61,7 @@ And(~'^offline mode is disabled with reachable internet$') {->
 }
 
 And(~'^offline mode is enabled with reachable internet$') {->
-    primeEndpoint("/broadcast/latest/id", "12345")
+    primeEndpointWithString("/broadcast/latest/id", "12345")
 
     forcedOffline = true
     online = true

--- a/src/test/steps/sdkman/stub_steps.groovy
+++ b/src/test/steps/sdkman/stub_steps.groovy
@@ -6,33 +6,33 @@ import static sdkman.utils.FilesystemUtils.readCurrentFromCandidateFolder
 import static sdkman.utils.FilesystemUtils.readVersionsCsvFromCandidateFolder
 
 And(~'^the default "([^"]*)" candidate is "([^"]*)"$') { String candidate, String version ->
-    primeEndpoint("/candidates/${candidate}/default", version)
+    primeEndpointWithString("/candidates/${candidate}/default", version)
     primeDownloadFor(SERVICE_UP_URL, candidate, version, PLATFORM)
 }
 
 And(~'^an available selfupdate$') { ->
-    primeEndpoint("/selfupdate", 'echo "Successfully upgraded SDKMAN."')
+    primeEndpointWithString("/selfupdate", 'echo "Successfully upgraded SDKMAN."')
 }
 
 And(~'^the candidate "([^"]*)" version "([^"]*)" is available for download$') { String candidate, String version ->
-    primeEndpoint("/candidates/${candidate}/${version}", "valid")
+    primeEndpointWithString("/candidates/${candidate}/${version}", "valid")
     primeDownloadFor(SERVICE_UP_URL, candidate, version, PLATFORM)
 }
 
 And(~'^the candidate "([^"]*)" version "([^"]*)" is not available for download$') { String candidate, String version ->
-    primeEndpoint("/candidates/${candidate}/${version}", "invalid")
+    primeEndpointWithString("/candidates/${candidate}/${version}", "invalid")
 }
 
 And(~'^a "([^"]*)" list view is available for consumption$') { String candidate ->
-    primeEndpoint("/candidates/${candidate}/list?platform=${PLATFORM}&current=&installed=", "Available ${candidate.capitalize()} Versions")
+    primeEndpointWithString("/candidates/${candidate}/list?platform=${PLATFORM}&current=&installed=", "Available ${candidate.capitalize()} Versions")
 }
 
 And(~'^the candidate "([^"]*)" version "([^"]*)" is a valid candidate version$') { String candidate, String version ->
-    primeEndpoint("/candidates/${candidate}/${version}", "valid")
+    primeEndpointWithString("/candidates/${candidate}/${version}", "valid")
 }
 
 And(~'^the candidate "([^"]*)" version "([^"]*)" is not a valid candidate version$') { String candidate, String version ->
-    primeEndpoint("/candidates/${candidate}/${version}", "invalid")
+    primeEndpointWithString("/candidates/${candidate}/${version}", "invalid")
 }
 
 And(~/^the candidate "(.*?)" has a version list available$/) { String candidate ->
@@ -40,9 +40,9 @@ And(~/^the candidate "(.*?)" has a version list available$/) { String candidate 
     def versions = readVersionsCsvFromCandidateFolder(candidatesDir, candidate)
     def url = "/candidates/${candidate}/list?platform=${PLATFORM}&current=${current}&installed=${versions}"
 
-    primeEndpoint(url, "Candidate: $candidate; Versions: $versions; Current: $current")
+    primeEndpointWithString(url, "Candidate: $candidate; Versions: $versions; Current: $current")
 }
 
 And(~/^The candidate list is available$/) { ->
-    primeEndpoint("/candidates/list", "Candidate List")
+    primeEndpointWithString("/candidates/list", "Candidate List")
 }


### PR DESCRIPTION
Apparently it's not possible to add afterAll hooks into cucumber groovy. That means that as a Wiremock instance is created on startup on 8080 if you want to use Wiremock in non-cucumber tests you have two options: 

1. Creating another Wiremock instance in another port.
2. Reusing previous instance.

First solution is not doable as current setup relies on `prepareTestScripts` gradle task. Install script has the following reference, `SDKMAN_SERVICE="@SDKMAN_SERVICE@"`, that means than even if we set `SDKMAN_SERVICE` to `http://localhost:8081` at `CleanBashEnvBuilder` the value will be overridden by the one set up at `build.gradle`. That's why `CleanBashEnvBuilder` is not even setting up those variables. 

Therefore this PR goes with second proposed option. 