### PR TITLE
Provide hook to disable GVM alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,7 @@ To install SDKMAN locally running against your local server, run the following c
 
 	$ ./gradlew install
 	$ source ~/.sdkman/bin/sdkman-init.sh
+
+### Disabling the GVM alias
+
+By default we `alias gvm="sdk"` for backwards compatibility. However, if you'd like to disable this, you can by setting `sdkman_disable_gvm_alias=true` in `${SDKMAN_DIR}/etc/config`

--- a/src/main/bash/install.sh
+++ b/src/main/bash/install.sh
@@ -208,6 +208,7 @@ touch "${sdkman_config_file}"
 echo "sdkman_auto_answer=false" >> "${sdkman_config_file}"
 echo "sdkman_auto_selfupdate=false" >> "${sdkman_config_file}"
 echo "sdkman_insecure_ssl=false" >> "${sdkman_config_file}"
+echo "sdkman_disable_gvm_alias=false" >> "${sdkman_config_file}"
 
 echo "Download script archive..."
 curl -s "${SDKMAN_SERVICE}/res?platform=${sdkman_platform}&purpose=install" > "${sdkman_zip_file}"

--- a/src/main/bash/sdkman-init.sh
+++ b/src/main/bash/sdkman-init.sh
@@ -206,4 +206,6 @@ done
 unset i
 export PATH
 
-alias gvm="sdk"
+if [[ ${sdkman_disable_gvm_alias} != true ]] ; then
+	alias gvm="sdk"
+fi

--- a/src/main/bash/selfupdate.sh
+++ b/src/main/bash/selfupdate.sh
@@ -241,6 +241,9 @@ if [[ -z $(cat ${sdkman_config_file} | grep 'sdkman_insecure_ssl') ]]; then
 	echo "sdkman_insecure_ssl=false" >> "${sdkman_config_file}"
 fi
 
+if [[ -z $(cat ${sdkman_config_file} | grep 'sdkman_disable_gvm_alias') ]]; then
+    echo "sdkman_disable_gvm_alias=false" >> "${sdkman_config_file}"
+fi
 
 # drop version token
 echo "$SDKMAN_VERSION" > "${SDKMAN_DIR}/var/version"


### PR DESCRIPTION
This would be nice so that I can now actually run both sdkman and [gvm](https://github.com/moovweb/gvm) side by side. :smile: 

Awesome job with the total rebrand btw - this is super duper awesome!