### PR TITLE
FEATURE #388 - Add more specs for install script.

### DIFF
--- a/src/test/groovy/sdkman/specs/InstallSpec.groovy
+++ b/src/test/groovy/sdkman/specs/InstallSpec.groovy
@@ -41,6 +41,160 @@ class InstallSpec extends Specification {
         sdkmanInitScript.exists()
     }
 
+    void "should skip installation if SDKMAN has been already installed"() {
+        given:
+        new File(sdkmanBaseDir, ".sdkman").mkdirs()
+
+        when:
+        bash.execute("curl -s ${service} | bash")
+
+        then:
+        bash.output.contains('You already have SDKMAN installed')
+    }
+
+    void "should store version in var/version file"() {
+        when:
+        bash.execute("curl -s ${service} | bash")
+
+        then:
+        bash.execute("cat ${sdkmanBaseDir}/.sdkman/var/version")
+        bash.output.trim() == 'x.y.z'
+    }
+
+    void "should update existing bash_profile when sdkman snippet is not present"() {
+        given:
+        new File(sdkmanBaseDir, ".bash_profile").createNewFile()
+
+        when:
+        bash.execute("curl -s ${service} | bash")
+
+        then:
+        bash.output.contains("Updated existing ${sdkmanBaseDir}/.bash_profile")
+        bash.execute("cat ${sdkmanBaseDir}/.bash_profile")
+        bash.output.contains('#THIS MUST BE AT THE END OF THE FILE FOR SDKMAN TO WORK!!!')
+    }
+
+    void "should skip updating existing bash_profile when sdkman snippet is present"() {
+        given:
+        def file = new File(sdkmanBaseDir, ".bash_profile")
+        file.createNewFile()
+        file.write "sdkman-init.sh"
+
+        when:
+        bash.execute("curl -s ${service} | bash")
+
+        then:
+        !bash.output.contains("Updated existing ${sdkmanBaseDir}/.bash_profile")
+    }
+
+    void "should update existing profile when sdkman snippet is not present"() {
+        given:
+        new File(sdkmanBaseDir, ".profile").createNewFile()
+
+        when:
+        bash.execute("curl -s ${service} | bash")
+
+        then:
+        bash.output.contains("Updated existing ${sdkmanBaseDir}/.profile")
+        bash.execute("cat ${sdkmanBaseDir}/.profile")
+        bash.output.contains('#THIS MUST BE AT THE END OF THE FILE FOR SDKMAN TO WORK!!!')
+    }
+
+    void "should skip updating existing profile when sdkman snippet is present"() {
+        given:
+        def file = new File(sdkmanBaseDir, ".profile")
+        file.createNewFile()
+        file.write "sdkman-init.sh"
+
+        when:
+        bash.execute("curl -s ${service} | bash")
+
+        then:
+        !bash.output.contains("Updated existing ${sdkmanBaseDir}/.profile")
+    }
+
+    void "should update existing bashrc when sdkman snippet is not present"() {
+        given:
+        new File(sdkmanBaseDir, ".bashrc").createNewFile()
+
+        when:
+        bash.execute("curl -s ${service} | bash")
+
+        then:
+        bash.output.contains("Updated existing ${sdkmanBaseDir}/.bashrc")
+        bash.execute("cat ${sdkmanBaseDir}/.bashrc")
+        bash.output.contains('#THIS MUST BE AT THE END OF THE FILE FOR SDKMAN TO WORK!!!')
+    }
+
+    void "should skip updating existing bashrc when sdkman snippet is present"() {
+        given:
+        def file = new File(sdkmanBaseDir, ".bashrc")
+        file.createNewFile()
+        file.write "sdkman-init.sh"
+
+        when:
+        bash.execute("curl -s ${service} | bash")
+
+        then:
+        !bash.output.contains("Updated existing ${sdkmanBaseDir}/.bashrc")
+    }
+
+    void "should update existing zshrc when sdkman snippet is not present"() {
+        given:
+        new File(sdkmanBaseDir, ".zshrc").createNewFile()
+
+        when:
+        bash.execute("curl -s ${service} | bash")
+
+        then:
+        bash.output.contains("Updated existing ${sdkmanBaseDir}/.zshrc")
+        bash.execute("cat ${sdkmanBaseDir}/.zshrc")
+        bash.output.contains('#THIS MUST BE AT THE END OF THE FILE FOR SDKMAN TO WORK!!!')
+    }
+
+    void "should skip updating existing zshrc when sdkman snippet is present"() {
+        given:
+        def file = new File(sdkmanBaseDir, ".zshrc")
+        file.createNewFile()
+        file.write "sdkman-init.sh"
+
+        when:
+        bash.execute("curl -s ${service} | bash")
+
+        then:
+        !bash.output.contains("Updated existing ${sdkmanBaseDir}/.zshrc")
+    }
+
+    void "should create bash_profile when not present"() {
+        when:
+        bash.execute("curl -s ${service} | bash")
+
+        then:
+        bash.output.contains("Created and initialised ${sdkmanBaseDir}/.bash_profile")
+        bash.execute("cat ${sdkmanBaseDir}/.bash_profile")
+        bash.output.contains('#THIS MUST BE AT THE END OF THE FILE FOR SDKMAN TO WORK!!!')
+    }
+
+    void "should create bashrc when not present"() {
+        when:
+        bash.execute("curl -s ${service} | bash")
+
+        then:
+        bash.output.contains("Created and initialised ${sdkmanBaseDir}/.bashrc")
+        bash.execute("cat ${sdkmanBaseDir}/.bashrc")
+        bash.output.contains('#THIS MUST BE AT THE END OF THE FILE FOR SDKMAN TO WORK!!!')
+    }
+
+    void "should create zshrc when not present"() {
+        when:
+        bash.execute("curl -s ${service} | bash")
+
+        then:
+        bash.output.contains("Created and initialised ${sdkmanBaseDir}/.zshrc")
+        bash.execute("cat ${sdkmanBaseDir}/.zshrc")
+        bash.output.contains('#THIS MUST BE AT THE END OF THE FILE FOR SDKMAN TO WORK!!!')
+    }
+
     private static primeInstallScriptEndpoint() {
         primeEndpointWithString("/", ("build/testScripts/install.sh" as File).text)
     }


### PR DESCRIPTION
This PR won’t tackle tests relying on tooling installed on the host machine. Current solution for using a Java process that wraps a bash session has the following shortcomings:

- Current bash isolation boundaries are not enough ambitious. Those boundaries are the filesystem, as every file that will be manipulated by SDKMAN production scripts will be isolated in some tmp folder. However there is no isolation (or dependency injection) regarding Unix tooling used by those scripts. If we delete one of those tools (testing that unzip is not present in the system), we’ll mess with the host environment.
- Unix tooling are slightly different in BSD and GNU. That means that these tests are currently OS dependant creating brittle test suites or code that is not tested from a portability point of view.

Some suggested solution is using Vagrant. That will give us complete isolation from the host, so we could execute the tests in a farm of different operative systems. This improvement is out of scope for this PR.