### PR TITLE
check for `bin` dir inside SDKMAN_DIR to check previous installation

### DIFF
--- a/src/main/bash/install.sh
+++ b/src/main/bash/install.sh
@@ -110,7 +110,7 @@ echo '                                                                          
 # Sanity checks
 
 echo "Looking for a previous installation of SDKMAN..."
-if [ -d "$SDKMAN_DIR" ]; then
+if [ -d "$sdkman_bin_folder" ]; then
 	echo "SDKMAN found."
 	echo ""
 	echo "======================================================================================================"


### PR DESCRIPTION
should fix #282

If you have existing dotfiles setup, `~/.sdkman/etc/config` is already present (as a symlink).