### PR TITLE
Update Path check to include SDKMAN path

### DIFF
--- a/src/main/bash/sdkman-current.sh
+++ b/src/main/bash/sdkman-current.sh
@@ -51,7 +51,7 @@ function __sdkman_determine_current_version {
 	local candidate present
 
 	candidate="$1"
-	present=$(__sdkman_path_contains "$candidate")
+	present=$(__sdkman_path_contains "${SDKMAN_CANDIDATES_DIR}/${candidate}")
 	if [[  "$present" == 'true' ]]; then
 		if [[ "$solaris" == true ]]; then
 			CURRENT=$(echo $PATH | gsed -r "s|${SDKMAN_CANDIDATES_DIR}/${candidate}/([^/]+)/bin|!!\1!!|1" | gsed -r "s|^.*!!(.+)!!.*$|\1|g")


### PR DESCRIPTION
This fixes an issue where the entire path was being added for the current
version if the candidate itself was on the path, but not part of SDKMAN
path

Fixes #422 