### PR TITLE
use /usr/bin/env for rm, mv, mkdir, ln

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ script:
 after_success:
   - docker run --rm -e BINTRAY_USERNAME=$BINTRAY_USERNAME -e BINTRAY_API_KEY=$BINTRAY_API_KEY -e TRAVIS_BUILD_NUMBER=$TRAVIS_BUILD_NUMBER -v $PWD:/usr/src/app -v $HOME/.gradle:/root/.gradle sdkman/sdkman-cli -Penv=production clean assemble bintrayUpload
 before_cache:
-  - sudo rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
+  - sudo /usr/bin/env rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
 cache:
   directories:
   - "$HOME/.gradle/caches/"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM java:8
 
 # Copy all here
-RUN mkdir -p /usr/src/app
+RUN /usr/bin/env mkdir -p /usr/src/app
 ADD . /usr/src/app
 WORKDIR /usr/src/app
 

--- a/bin/build_drone.sh
+++ b/bin/build_drone.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 RELEASE=$(grep 'sdkmanVersion' config.groovy | sed 's_sdkmanVersion = __g' | tr -d "'")
 
 if [[ "$RELEASE" == "1.0.0-SNAPSHOT" ]]; then

--- a/bin/build_travis.sh
+++ b/bin/build_travis.sh
@@ -1,3 +1,2 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 ./gradlew -Penv=production clean test assemble

--- a/bin/download.sh
+++ b/bin/download.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 CANDIDATE="$1"
 VERSION="$2"
 
@@ -23,12 +22,12 @@ function download_archive {
 
 if [ -d "$TMP_DIR" ]; then
     echo "Cleaning up temporary folder..."
-    rm -rf "$TMP_DIR"
+    /usr/bin/env rm -rf "$TMP_DIR"
 fi
 
-mkdir -p "$BASE_DIR"
-mkdir -p "$ARCHIVE_DIR"
-mkdir "$TMP_DIR"
+/usr/bin/env mkdir -p "$BASE_DIR"
+/usr/bin/env mkdir -p "$ARCHIVE_DIR"
+/usr/bin/env mkdir "$TMP_DIR"
 
 if [ -d "$DESTINATION_DIR" ]; then
     echo "Version $VERSION of $CANDIDATE already found, skipping installation."
@@ -49,7 +48,7 @@ fi
 
 echo "Extracting archive to: $DESTINATION_DIR"
 unzip -oq "$ARCHIVE" -d "$TMP_DIR"
-mkdir "$DESTINATION_DIR"
-mv "$TMP_DIR"/**/* "$DESTINATION_DIR"
+/usr/bin/env mkdir "$DESTINATION_DIR"
+/usr/bin/env mv "$TMP_DIR"/**/* "$DESTINATION_DIR"
 
-rm -rf "$TMP_DIR"
+/usr/bin/env rm -rf "$TMP_DIR"

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 VERSION="$1"
 BRANCH="production"
 

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 if [ -z $(which java) ]; then
 	echo "Please install java before continuing..."
 fi

--- a/src/main/bash/sdkman-availability.sh
+++ b/src/main/bash/sdkman-availability.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 #
 #   Copyright 2012 Marco Vermeulen
 #
@@ -17,8 +16,8 @@
 #
 
 function __sdkman_update_broadcast_and_service_availability {
-    local broadcast_live_id=$(__sdkman_determine_broadcast_id)
-    __sdkman_set_availability "$broadcast_live_id"
+	local broadcast_live_id=$(__sdkman_determine_broadcast_id)
+	__sdkman_set_availability "$broadcast_live_id"
 	__sdkman_update_broadcast "$broadcast_live_id"
 }
 
@@ -31,7 +30,7 @@ function __sdkman_determine_broadcast_id {
 }
 
 function __sdkman_set_availability {
-    local broadcast_id="$1"
+	local broadcast_id="$1"
 	local detect_html="$(echo "$broadcast_id" | tr '[:upper:]' '[:lower:]' | grep 'html')"
 	if [[ -z "$broadcast_id" ]]; then
 		SDKMAN_AVAILABLE="false"
@@ -47,15 +46,15 @@ function __sdkman_set_availability {
 function __sdkman_display_offline_warning {
 	local broadcast_id="$1"
 	if [[ -z "$broadcast_id" && "$COMMAND" != "offline" && "$SDKMAN_OFFLINE_MODE" != "true" ]]; then
-        echo "==== INTERNET NOT REACHABLE! ==============================="
-        echo ""
-        echo " Some functionality is disabled or only partially available."
-        echo " If this persists, please enable the offline mode:"
-        echo ""
-        echo "   $ sdk offline"
-        echo ""
-        echo "============================================================"
-        echo ""
+		echo "==== INTERNET NOT REACHABLE! ==============================="
+		echo ""
+		echo " Some functionality is disabled or only partially available."
+		echo " If this persists, please enable the offline mode:"
+		echo ""
+		echo "   $ sdk offline"
+		echo ""
+		echo "============================================================"
+		echo ""
 	fi
 }
 
@@ -63,7 +62,7 @@ function __sdkman_display_proxy_warning {
 	echo "==== PROXY DETECTED! ======================================="
 	echo "Please ensure you have open internet access to continue."
 	echo "============================================================"
-    echo ""
+	echo ""
 }
 
 function __sdkman_update_broadcast {
@@ -83,7 +82,7 @@ function __sdkman_update_broadcast {
 	fi
 
 	if [[ "$SDKMAN_AVAILABLE" == "true" && "$broadcast_live_id" != "$broadcast_old_id" && "$COMMAND" != "selfupdate" && "$COMMAND" != "flush" ]]; then
-		mkdir -p "${SDKMAN_DIR}/var"
+		/usr/bin/env mkdir -p "${SDKMAN_DIR}/var"
 
 		echo "$broadcast_live_id" > "$broadcast_id_file"
 

--- a/src/main/bash/sdkman-broadcast.sh
+++ b/src/main/bash/sdkman-broadcast.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 #
 #   Copyright 2012 Marco Vermeulen
 #

--- a/src/main/bash/sdkman-current.sh
+++ b/src/main/bash/sdkman-current.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 #
 #   Copyright 2012 Marco Vermeulen
 #

--- a/src/main/bash/sdkman-default.sh
+++ b/src/main/bash/sdkman-default.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 #
 #   Copyright 2012 Marco Vermeulen
 #

--- a/src/main/bash/sdkman-env-helpers.sh
+++ b/src/main/bash/sdkman-env-helpers.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 #
 #   Copyright 2012 Marco Vermeulen
 #

--- a/src/main/bash/sdkman-flush.sh
+++ b/src/main/bash/sdkman-flush.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 #
 #   Copyright 2012 Marco Vermeulen
 #
@@ -22,7 +21,7 @@ function __sdk_flush {
 	case "$qualifier" in
 		candidates)
 			if [[ -f "${SDKMAN_DIR}/var/candidates" ]]; then
-		        rm "${SDKMAN_DIR}/var/candidates"
+		        /usr/bin/env rm "${SDKMAN_DIR}/var/candidates"
 		        echo "Candidates have been flushed."
 		    else
 		        echo "No candidate list found so not flushed."
@@ -30,7 +29,7 @@ function __sdk_flush {
 		    ;;
 		broadcast)
 			if [[ -f "${SDKMAN_DIR}/var/broadcast" ]]; then
-		        rm "${SDKMAN_DIR}/var/broadcast"
+		        /usr/bin/env rm "${SDKMAN_DIR}/var/broadcast"
 		        echo "Broadcast has been flushed."
 		    else
 		        echo "No prior broadcast found so not flushed."
@@ -38,7 +37,7 @@ function __sdk_flush {
 		    ;;
 		version)
 			if [[ -f "${SDKMAN_DIR}/var/version" ]]; then
-		        rm "${SDKMAN_DIR}/var/version"
+		        /usr/bin/env rm "${SDKMAN_DIR}/var/version"
 		        echo "Version Token has been flushed."
 		    else
 		        echo "No prior Remote Version found so not flushed."
@@ -65,8 +64,8 @@ function __sdkman_cleanup_folder {
 	sdkman_cleanup_disk_usage=$(du -sh "$sdkman_cleanup_dir")
 	sdkman_cleanup_count=$(ls -1 "$sdkman_cleanup_dir" | wc -l)
 
-	rm -rf "${SDKMAN_DIR}/${folder}"
-	mkdir "${SDKMAN_DIR}/${folder}"
+	/usr/bin/env rm -rf "${SDKMAN_DIR}/${folder}"
+	/usr/bin/env mkdir "${SDKMAN_DIR}/${folder}"
 
 	echo "${sdkman_cleanup_count} archive(s) flushed, freeing ${sdkman_cleanup_disk_usage}."
 }

--- a/src/main/bash/sdkman-help.sh
+++ b/src/main/bash/sdkman-help.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 #
 #   Copyright 2012 Marco Vermeulen
 #

--- a/src/main/bash/sdkman-init.sh
+++ b/src/main/bash/sdkman-init.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 #
 #   Copyright 2012 Marco Vermeulen
 #

--- a/src/main/bash/sdkman-install.sh
+++ b/src/main/bash/sdkman-install.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 #
 #   Copyright 2012 Marco Vermeulen
 #
@@ -66,11 +65,11 @@ function __sdkman_install_candidate_version {
 	__sdkman_download "$candidate" "$version" || return 1
 	echo "Installing: ${candidate} ${version}"
 
-	mkdir -p "${SDKMAN_CANDIDATES_DIR}/${candidate}"
+	/usr/bin/env mkdir -p "${SDKMAN_CANDIDATES_DIR}/${candidate}"
 
-	rm -rf "${SDKMAN_DIR}/tmp/out"
+	/usr/bin/env rm -rf "${SDKMAN_DIR}/tmp/out"
 	unzip -oq "${SDKMAN_DIR}/archives/${candidate}-${version}.zip" -d "${SDKMAN_DIR}/tmp/out"
-	mv "$SDKMAN_DIR"/tmp/out/* "${SDKMAN_CANDIDATES_DIR}/${candidate}/${version}"
+	/usr/bin/env mv "$SDKMAN_DIR"/tmp/out/* "${SDKMAN_CANDIDATES_DIR}/${candidate}/${version}"
 	echo "Done installing!"
 	echo ""
 }
@@ -82,10 +81,10 @@ function __sdkman_install_local_version {
 	version="$2"
 	folder="$3"
 
-	mkdir -p "${SDKMAN_CANDIDATES_DIR}/${candidate}"
+	/usr/bin/env mkdir -p "${SDKMAN_CANDIDATES_DIR}/${candidate}"
 
 	echo "Linking ${candidate} ${version} to ${folder}"
-	ln -s "$folder" "${SDKMAN_CANDIDATES_DIR}/${candidate}/${version}"
+	/usr/bin/env ln -s "$folder" "${SDKMAN_CANDIDATES_DIR}/${candidate}/${version}"
 	echo "Done installing!"
 	echo ""
 }
@@ -95,7 +94,7 @@ function __sdkman_download {
 
 	candidate="$1"
 	version="$2"
-	mkdir -p "${SDKMAN_DIR}/archives"
+	/usr/bin/env mkdir -p "${SDKMAN_DIR}/archives"
 	if [ ! -f "${SDKMAN_DIR}/archives/${candidate}-${version}.zip" ]; then
 		echo ""
 		echo "Downloading: ${candidate} ${version}"
@@ -119,7 +118,7 @@ function __sdkman_validate_zip {
 	zip_archive="$1"
 	zip_ok=$(unzip -t "$zip_archive" | grep 'No errors detected in compressed data')
 	if [ -z "$zip_ok" ]; then
-		rm "$zip_archive"
+		/usr/bin/env rm "$zip_archive"
 		echo ""
 		echo "Stop! The archive was corrupt and has been removed! Please try installing again."
 		return 1

--- a/src/main/bash/sdkman-list.sh
+++ b/src/main/bash/sdkman-list.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 #
 #   Copyright 2012 Marco Vermeulen
 #

--- a/src/main/bash/sdkman-main.sh
+++ b/src/main/bash/sdkman-main.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 #
 #   Copyright 2012 Marco Vermeulen
 #
@@ -49,7 +48,7 @@ function sdk {
 	#
 	# Various sanity checks and default settings
 	#
-	mkdir -p "$SDKMAN_DIR"
+	/usr/bin/env mkdir -p "$SDKMAN_DIR"
 
 	# Always presume internet availability
 	SDKMAN_AVAILABLE="true"

--- a/src/main/bash/sdkman-offline.sh
+++ b/src/main/bash/sdkman-offline.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 #
 #   Copyright 2012 Marco Vermeulen
 #

--- a/src/main/bash/sdkman-outdated.sh
+++ b/src/main/bash/sdkman-outdated.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 #
 #   Copyright 2012 Marco Vermeulen
 #

--- a/src/main/bash/sdkman-path-helpers.sh
+++ b/src/main/bash/sdkman-path-helpers.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 #
 #   Copyright 2012 Marco Vermeulen
 #
@@ -82,7 +81,7 @@ function __sdkman_link_candidate_version {
 
 	# Change the 'current' symlink for the candidate, hence affecting all shells.
 	if [[ -h "${SDKMAN_CANDIDATES_DIR}/${candidate}/current" || -d "${SDKMAN_CANDIDATES_DIR}/${candidate}/current" ]]; then
-		rm -f "${SDKMAN_CANDIDATES_DIR}/${candidate}/current"
+		/usr/bin/env rm -f "${SDKMAN_CANDIDATES_DIR}/${candidate}/current"
 	fi
 
 	function cygwin_ln(){
@@ -95,6 +94,6 @@ function __sdkman_link_candidate_version {
 	if [[ "$OSTYPE" == "cygwin" ]]; then
 		cygwin_ln "${SDKMAN_CANDIDATES_DIR}/${candidate}/current" "${SDKMAN_CANDIDATES_DIR}/${candidate}/${version}"
 	else
-		ln -s "${SDKMAN_CANDIDATES_DIR}/${candidate}/${version}" "${SDKMAN_CANDIDATES_DIR}/${candidate}/current"
+		/usr/bin/env ln -s "${SDKMAN_CANDIDATES_DIR}/${candidate}/${version}" "${SDKMAN_CANDIDATES_DIR}/${candidate}/current"
 	fi
 }

--- a/src/main/bash/sdkman-selfupdate.sh
+++ b/src/main/bash/sdkman-selfupdate.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 #
 #   Copyright 2012 Marco Vermeulen
 #

--- a/src/main/bash/sdkman-uninstall.sh
+++ b/src/main/bash/sdkman-uninstall.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 #
 #   Copyright 2012 Marco Vermeulen
 #
@@ -33,7 +32,7 @@ function __sdk_uninstall {
 	echo ""
 	if [ -d "${SDKMAN_CANDIDATES_DIR}/${candidate}/${version}" ]; then
 		echo "Uninstalling ${candidate} ${version}..."
-		rm -rf "${SDKMAN_CANDIDATES_DIR}/${candidate}/${version}"
+		/usr/bin/env rm -rf "${SDKMAN_CANDIDATES_DIR}/${candidate}/${version}"
 	else
 		echo "${candidate} ${version} is not installed."
 	fi

--- a/src/main/bash/sdkman-use.sh
+++ b/src/main/bash/sdkman-use.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 #
 #   Copyright 2012 Marco Vermeulen
 #

--- a/src/main/bash/sdkman-utils.sh
+++ b/src/main/bash/sdkman-utils.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 #
 #   Copyright 2012 Marco Vermeulen
 #

--- a/src/main/bash/sdkman-version.sh
+++ b/src/main/bash/sdkman-version.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 #
 #   Copyright 2012 Marco Vermeulen
 #


### PR DESCRIPTION
fixing https://github.com/sdkman/sdkman-cli/issues/451

> e.g. [sdkman-install.sh](https://github.com/sdkman/sdkman-cli/blob/master/src/main/bash/sdkman-install.sh) uses mkdir that is not a more or less secure bash function but might be overloaded by a simple user function. So, you should update any calls to `mkdir` to s.th. like `/usr/bin/env mkdir` to not execute the user function if it exist but the real mkdir binary.
> 
> This expands to many others like: `rm`, etc. too!
