### PR TITLE
Revert "Fix creating symlinks in cygwin (#302)"

### DIFF
--- a/src/main/bash/sdkman-path-helpers.sh
+++ b/src/main/bash/sdkman-path-helpers.sh
@@ -84,17 +84,5 @@ function __sdkman_link_candidate_version {
 	if [[ -h "${SDKMAN_CANDIDATES_DIR}/${candidate}/current" || -d "${SDKMAN_CANDIDATES_DIR}/${candidate}/current" ]]; then
 		rm -f "${SDKMAN_CANDIDATES_DIR}/${candidate}/current"
 	fi
-
-	function cygwin_ln(){
-		mapfile -t ph < <(cygpath -aw "$@")
-		[ -d "$2" ] && d=/d || d=
-		cmd /c mklink $d "${ph[@]}"
-	}
-
-	# cygwin doesn't handle symlinks properly, fall back to a proxy mklink
-	if [[ "$OSTYPE" == "cygwin" ]]; then
-		cygwin_ln "${SDKMAN_CANDIDATES_DIR}/${candidate}/current" "${SDKMAN_CANDIDATES_DIR}/${candidate}/${version}"
-	else
-		ln -s "${SDKMAN_CANDIDATES_DIR}/${candidate}/${version}" "${SDKMAN_CANDIDATES_DIR}/${candidate}/current"
-	fi
+	ln -s "${SDKMAN_CANDIDATES_DIR}/${candidate}/${version}" "${SDKMAN_CANDIDATES_DIR}/${candidate}/current"
 }


### PR DESCRIPTION
This reverts commit e3a4d4691845ecbc658fb420d7e3fc60a2491396.

This fixes issue #467. Cygwin can be configured to do what this commit did
by setting the following `export CYGWIN=winsymlinks:native`