### PR TITLE
Remove akka from list of candidates in help

### DIFF
--- a/src/main/bash/sdkman-help.sh
+++ b/src/main/bash/sdkman-help.sh
@@ -36,7 +36,7 @@ function __sdk_help {
 	echo "       selfupdate        [force]"
 	echo "       flush             <candidates|broadcast|archives|temp>"
 	echo ""
-	echo "   candidate  :  the SDK to install: groovy, scala, grails, akka, etc."
+	echo "   candidate  :  the SDK to install: groovy, scala, grails, gradle, etc."
 	echo "                 use list command for comprehensive list of candidates"
 	echo "                 eg: \$ sdk list"
 	echo ""

--- a/src/main/bash/sdkman-help.sh
+++ b/src/main/bash/sdkman-help.sh
@@ -36,7 +36,7 @@ function __sdk_help {
 	echo "       selfupdate        [force]"
 	echo "       flush             <candidates|broadcast|archives|temp>"
 	echo ""
-	echo "   candidate  :  the SDK to install: groovy, scala, grails, gradle, etc."
+	echo "   candidate  :  the SDK to install: groovy, scala, grails, kotlin, etc."
 	echo "                 use list command for comprehensive list of candidates"
 	echo "                 eg: \$ sdk list"
 	echo ""

--- a/src/main/bash/sdkman-help.sh
+++ b/src/main/bash/sdkman-help.sh
@@ -36,7 +36,7 @@ function __sdk_help {
 	echo "       selfupdate        [force]"
 	echo "       flush             <candidates|broadcast|archives|temp>"
 	echo ""
-	echo "   candidate  :  the SDK to install: groovy, scala, grails, kotlin, etc."
+	echo "   candidate  :  the SDK to install: groovy, scala, grails, gradle, kotlin, etc."
 	echo "                 use list command for comprehensive list of candidates"
 	echo "                 eg: \$ sdk list"
 	echo ""


### PR DESCRIPTION
The help lists akka as one of the candidates, which is weird, because it is not.
This change fixes that by replacing with gradle.

If there is a list of most popular things installed using sdkman, I can replace the list with things from that.