### PR TITLE
Don't use the output of `which` or `command -v`.

### DIFF
--- a/src/main/bash/sdkman-utils.sh
+++ b/src/main/bash/sdkman-utils.sh
@@ -55,10 +55,10 @@ function __sdkman_secure_curl_with_timeouts {
 }
 
 function __sdkman_page {
-    local PAGER="${PAGER-$(which less)}"
-
     if [[ -n "$PAGER" ]]; then
-        "$@" | "$PAGER"
+        "$@" | $PAGER
+    elif command -v less >& /dev/null; then
+        "$@" | less
     else
         "$@"
     fi


### PR DESCRIPTION
`which less` has the following output in some versions of Bash:

    less is /usr/bin/less

`command -v less` outputs the path, but unfortunately has non-executable output in the case of aliases:

    $ alias less='my-super-less'
    $ command -v less
    alias less='my-super-less'

In this change, we use the exit code, not the output. (Thanks @halyph.)

Closes #493.