### PR TITLE
Change random string generation to be Ansible friendly

### DIFF
--- a/src/main/bash/sdkman-install.sh
+++ b/src/main/bash/sdkman-install.sh
@@ -101,7 +101,7 @@ function __sdkman_download {
 
 		local platform_parameter="$(echo $SDKMAN_PLATFORM | tr '[:upper:]' '[:lower:]')"
 		local download_url="${SDKMAN_CURRENT_API}/broker/download/${candidate}/${version}/${platform_parameter}"
-		local base_name="$(cat /dev/urandom | env LC_CTYPE=C tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)"
+		local base_name="$(head /dev/urandom | env LC_CTYPE=C tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)"
 		local zip_archive_target="${SDKMAN_DIR}/archives/${candidate}-${version}.zip"
 
 		#pre-installation hook: implements function __sdkman_pre_installation_hook


### PR DESCRIPTION
First of all, the proposed change might not be the best solution and I have only tested it in Ubuntu.

I've been using `sdkman` for a while and I also use it in Ansible scripts while configuring a development environment. I hadn't had any issues so far but just recently it seemed to stop working. It basically hanged indefinitely while executing `sdk install XXX` commands through Ansible scripts, while running them directly from the shell worked well as usual.

I googled "bash stuck ansible" and found this: https://github.com/ansible/ansible/issues/12459
It didn't seemed related at the time but while reviewing the latest 'sdkman-cli` commits I saw something familiar: https://github.com/sdkman/sdkman-cli/commit/e37872123d6b48ed2784d1ab9219fa6c3cacc17f

It appears that using `cat /dev/urandom` might cause bash scripts run from Ansible to get stuck. I tried to use the solution posted in the Ansible issue but I couldn't make it work, so I looked for another way to generate a random string without using `/dev/urandom`.

The one that I've managed to make it work uses `date`, but since it also uses `sha256sum` and `base64` I'm not 100% sure it'll work in other OSs.

Please, feel free to provide an alternative solution, I'll be glad to test it using Ansible scripts if necessary.