### PR TITLE
Outdated command can update all outdated candidates

### DIFF
--- a/src/main/bash/sdkman-outdated.sh
+++ b/src/main/bash/sdkman-outdated.sh
@@ -17,7 +17,7 @@
 #
 
 function __sdk_outdated {
-    local all candidates candidate outdated installed_count outdated_count
+    local all candidates candidate outdated installed_count outdated_count outdated_candidates
     if [ -n "$1" ]; then
         all=false
         candidates=$1
@@ -43,6 +43,7 @@ function __sdk_outdated {
                     [ ${outdated_count} -eq 0 ] && echo "Outdated:"
                     echo "$outdated"
                     (( outdated_count += 1 ))
+                    outdated_candidates=(${outdated_candidates[@]} $candidate)
                 fi
                 (( installed_count += 1 ))
                 ;;
@@ -56,6 +57,15 @@ function __sdk_outdated {
         fi
     elif [ ${outdated_count} -eq 0 ]; then
         echo "${candidate} is up-to-date"
+    fi
+    if [ ${outdated_count} -gt 0 ]; then
+        echo -n "Do you want to update all candidates and set latest versions as default? (Y/n): "
+        read UPDATE_ALL
+        if [[ -z "$UPDATE_ALL" || "$UPDATE_ALL" == "y" || "$UPDATE_ALL" == "Y" ]]; then
+        for outdated_candidate in ${outdated_candidates}; do
+            echo "Y" | __sdk_install $outdated_candidate
+        done
+        fi
     fi
 }
 

--- a/src/test/cucumber/outdated_candidate.feature
+++ b/src/test/cucumber/outdated_candidate.feature
@@ -58,3 +58,51 @@ Feature: Outdated Candidate
     And the system is bootstrapped
     When I enter "sdk outdated"
     Then I see "All candidates are up-to-date"
+
+  Scenario: Update all outdated candidates versions and set them as default when none is specified and one is in use
+    Given the candidate "grails" version "1.3.9" is already installed and default
+    And the default "grails" version is "2.1.0"
+    And the candidate "grails" version "2.1.0" is available for download
+    And the system is bootstrapped
+    When I enter "sdk outdated" and answer "Y"
+    Then I see "Outdated:"
+    And I see "grails (1.3.9 < 2.1.0)"
+    And I see "Do you want to update all candidates and set latest versions as default? (Y/n)"
+    And I see "Do you want grails 2.1.0 to be set as default? (Y/n)"
+    And I see "Setting grails 2.1.0 as default."
+    Then the candidate "grails" version "2.1.0" should be the default
+
+  Scenario: Don't update all outdated candidates versions and set them as default when none is specified and one is in use
+    Given the candidate "grails" version "1.3.9" is already installed and default
+    And the default "grails" version is "2.1.0"
+    And the candidate "grails" version "2.1.0" is available for download
+    And the system is bootstrapped
+    When I enter "sdk outdated" and answer "N"
+    Then I see "Outdated:"
+    And I see "grails (1.3.9 < 2.1.0)"
+    And I see "Do you want to update all candidates and set latest versions as default? (Y/n)"
+    Then the candidate "grails" version "1.3.9" should be the default
+
+  Scenario: Update outdated candidate version and set it as default when is in use
+    Given the candidate "grails" version "1.3.9" is already installed and default
+    And the default "grails" version is "2.1.0"
+    And the candidate "grails" version "2.1.0" is available for download
+    And the system is bootstrapped
+    When I enter "sdk outdated grails" and answer "Y"
+    Then I see "Outdated:"
+    And I see "grails (1.3.9 < 2.1.0)"
+    And I see "Do you want to update all candidates and set latest versions as default? (Y/n)"
+    And I see "Do you want grails 2.1.0 to be set as default? (Y/n)"
+    And I see "Setting grails 2.1.0 as default."
+    Then the candidate "grails" version "2.1.0" should be the default
+
+  Scenario: Don't update outdated candidate version and set it as default when is in use
+    Given the candidate "grails" version "1.3.9" is already installed and default
+    And the default "grails" version is "2.1.0"
+    And the candidate "grails" version "2.1.0" is available for download
+    And the system is bootstrapped
+    When I enter "sdk outdated grails" and answer "N"
+    Then I see "Outdated:"
+    And I see "grails (1.3.9 < 2.1.0)"
+    And I see "Do you want to update all candidates and set latest versions as default? (Y/n)"
+    Then the candidate "grails" version "1.3.9" should be the default


### PR DESCRIPTION
The purpose of this PR is to provide a way to update all the outdated candidates and set them as the default version.

When running `sdk outdated`, with or without a specific candidate, and only if there is any outdated candidate, ask the user for confirmation on updating all of them and setting them as the default, and do so accordingly.