### PR TITLE
Rename outdated to upgrade

### DIFF
--- a/src/main/bash/sdkman-help.sh
+++ b/src/main/bash/sdkman-help.sh
@@ -28,7 +28,7 @@ function __sdk_help {
 	__sdkman_echo_white "       use       or u    <candidate> [version]"
 	__sdkman_echo_white "       default   or d    <candidate> [version]"
 	__sdkman_echo_white "       current   or c    [candidate]"
-	__sdkman_echo_white "       outdated  or o    [candidate]"
+	__sdkman_echo_white "       upgrade   or ug    [candidate]"
 	__sdkman_echo_white "       version   or v"
 	__sdkman_echo_white "       broadcast or b"
 	__sdkman_echo_white "       help      or h"

--- a/src/main/bash/sdkman-install.sh
+++ b/src/main/bash/sdkman-install.sh
@@ -36,7 +36,7 @@ function __sdk_install {
 		__sdkman_determine_current_version "$candidate"
 		__sdkman_install_candidate_version "$candidate" "$VERSION" || return 1
 
-		if [[ "$sdkman_auto_answer" != 'true' && "$auto_answer_outdated" != 'true' && -n "$CURRENT" ]]; then
+		if [[ "$sdkman_auto_answer" != 'true' && "$auto_answer_upgrade" != 'true' && -n "$CURRENT" ]]; then
 			__sdkman_echo_confirm "Do you want ${candidate} ${VERSION} to be set as default? (Y/n): "
 			read USE
 		fi

--- a/src/main/bash/sdkman-main.sh
+++ b/src/main/bash/sdkman-main.sh
@@ -38,8 +38,12 @@ function sdk {
             COMMAND="uninstall";;
         c)
             COMMAND="current";;
+        ug)
+            COMMAND="upgrade";;
+        outdated)
+            COMMAND="upgrade";;
         o)
-            COMMAND="outdated";;
+            COMMAND="upgrade";;
         d)
             COMMAND="default";;
         b)

--- a/src/main/bash/sdkman-upgrade.sh
+++ b/src/main/bash/sdkman-upgrade.sh
@@ -16,8 +16,8 @@
 #   limitations under the License.
 #
 
-function __sdk_outdated {
-    local all candidates candidate outdated installed_count outdated_count outdated_candidates
+function __sdk_upgrade {
+    local all candidates candidate upgradable installed_count upgradable_count upgradable_candidates
     if [ -n "$1" ]; then
         all=false
         candidates=$1
@@ -26,10 +26,10 @@ function __sdk_outdated {
         candidates=${SDKMAN_CANDIDATES[@]}
     fi
     installed_count=0
-    outdated_count=0
+    upgradable_count=0
     echo ""
     for candidate in ${candidates}; do
-        outdated="$(__sdkman_determine_outdated_version "$candidate")"
+        upgradable="$(__sdkman_determine_upgradable_version "$candidate")"
         case $? in
             1)
                 $all || __sdkman_echo_red "Not using any version of ${candidate}"
@@ -40,11 +40,11 @@ function __sdk_outdated {
                 return 1
                 ;;
             *)
-                if [ -n "$outdated" ]; then
-                    [ ${outdated_count} -eq 0 ] && __sdkman_echo_white "Outdated:"
-                    __sdkman_echo_white "$outdated"
-                    (( outdated_count += 1 ))
-                    outdated_candidates=(${outdated_candidates[@]} $candidate)
+                if [ -n "$upgradable" ]; then
+                    [ ${upgradable_count} -eq 0 ] && __sdkman_echo_white "Upgrade:"
+                    __sdkman_echo_white "$upgradable"
+                    (( upgradable_count += 1 ))
+                    upgradable_candidates=(${upgradable_candidates[@]} $candidate)
                 fi
                 (( installed_count += 1 ))
                 ;;
@@ -53,27 +53,27 @@ function __sdk_outdated {
     if $all; then
         if [ ${installed_count} -eq 0 ]; then
             __sdkman_echo_white 'No candidates are in use'
-        elif [ ${outdated_count} -eq 0 ]; then
+        elif [ ${upgradable_count} -eq 0 ]; then
             __sdkman_echo_white "All candidates are up-to-date"
         fi
-    elif [ ${outdated_count} -eq 0 ]; then
+    elif [ ${upgradable_count} -eq 0 ]; then
         __sdkman_echo_white "${candidate} is up-to-date"
     fi
-    if [ ${outdated_count} -gt 0 ]; then
+    if [ ${upgradable_count} -gt 0 ]; then
         echo ""
-        __sdkman_echo_confirm "Update candidate(s) and set latest version(s) as default? (Y/n): "
-        read UPDATE_ALL
-        export auto_answer_outdated='true'
-        if [[ -z "$UPDATE_ALL" || "$UPDATE_ALL" == "y" || "$UPDATE_ALL" == "Y" ]]; then
-            for outdated_candidate in ${outdated_candidates}; do
-                __sdk_install $outdated_candidate
+        __sdkman_echo_confirm "Upgrade candidate(s) and set latest version(s) as default? (Y/n): "
+        read UPGRADE_ALL
+        export auto_answer_upgrade='true'
+        if [[ -z "$UPGRADE_ALL" || "$UPGRADE_ALL" == "y" || "$UPGRADE_ALL" == "Y" ]]; then
+            for upgradable_candidate in ${upgradable_candidates}; do
+                __sdk_install $upgradable_candidate
             done
         fi
-        unset auto_answer_outdated
+        unset auto_answer_upgrade
     fi
 }
 
-function __sdkman_determine_outdated_version {
+function __sdkman_determine_upgradable_version {
     local candidate local_versions remote_default_version
 
     candidate="$1"
@@ -90,7 +90,7 @@ function __sdkman_determine_outdated_version {
         return 2
     fi
 
-    # Check outdated or not
+    # Check upgradable or not
     if [ ! -d "${SDKMAN_CANDIDATES_DIR}/${candidate}/${remote_default_version}" ]; then
         __sdkman_echo_yellow "${candidate} (${local_versions} < ${remote_default_version})"
     fi

--- a/src/test/cucumber/mnemonics.feature
+++ b/src/test/cucumber/mnemonics.feature
@@ -38,24 +38,21 @@ Feature: Mnemonics
     And I see "grails: 2.1.0"
     And I see "groovy: 2.0.5"
 
-  Scenario: Shortcut for displaying outdated Candidate Version in use
+  Scenario: Shortcut for displaying upgradable Candidate Version in use
+    Given the candidate "grails" version "1.3.9" is already installed and default
+    And the default "grails" version is "2.4.4"
+    And the system is bootstrapped
+    When I enter "sdk ug grails"
+    Then I see "Upgrade:"
+    And I see "grails (1.3.9 < 2.4.4)"
+
+  Scenario: Deprecated shortcut for displaying upgradable Candidate Version in use, supported for backwards compatibility
     Given the candidate "grails" version "1.3.9" is already installed and default
     And the default "grails" version is "2.4.4"
     And the system is bootstrapped
     When I enter "sdk o grails"
-    Then I see "Outdated:"
+    Then I see "Upgrade:"
     And I see "grails (1.3.9 < 2.4.4)"
-
-  Scenario: Shortcut for displaying outdated Candidate Versions
-    Given  the candidate "grails" version "1.3.9" is already installed and default
-    And the default "grails" version is "2.4.4"
-    And the candidate "groovy" version "2.0.5" is already installed and default
-    And the default "groovy" version is "2.4.1"
-    And the system is bootstrapped
-    When I enter "sdk o"
-    Then I see "Outdated:"
-    And I see "grails (1.3.9 < 2.4.4)"
-    And I see "groovy (2.0.5 < 2.4.1)"
 
   Scenario: Shortcut for installing a Candidate Version
     Given the candidate "grails" version "2.1.0" is not installed
@@ -102,4 +99,3 @@ Feature: Mnemonics
     And the system is bootstrapped
     When I enter "sdk b"
     Then I see "This is a LIVE Broadcast!"
-

--- a/src/test/cucumber/upgrade_candidate.feature
+++ b/src/test/cucumber/upgrade_candidate.feature
@@ -1,108 +1,108 @@
-Feature: Outdated Candidate
+Feature: Upgrade Candidate
 
   Background:
     Given the internet is reachable
     And an initialised environment
 
-  Scenario: Display outdated candidate version in use when it is outdated
+  Scenario: Display upgradable candidate version in use when it is upgradable
     Given the candidate "grails" version "1.3.9" is already installed and default
     And the default "grails" version is "2.4.4"
     And the system is bootstrapped
-    When I enter "sdk outdated grails"
-    Then I see "Outdated:"
+    When I enter "sdk upgrade grails"
+    Then I see "Upgrade:"
     And I see "grails (1.3.9 < 2.4.4)"
 
-  Scenario: Display outdated candidate version in use when it is not outdated
+  Scenario: Display upgradable candidate version in use when it is not upgradable
     Given the candidate "grails" version "1.3.9" is already installed and default
     And the default "grails" version is "1.3.9"
     And the system is bootstrapped
-    When I enter "sdk outdated grails"
+    When I enter "sdk upgrade grails"
     Then I see "grails is up-to-date"
 
-  Scenario: Display outdated candidate version when none is in use
+  Scenario: Display upgradable candidate version when none is in use
     Given the candidate "grails" does not exist locally
     And the system is bootstrapped
-    When I enter "sdk outdated grails"
+    When I enter "sdk upgrade grails"
     Then I see "Not using any version of grails"
 
-  Scenario: Display outdated candidate versions when none is specified and none is in use
+  Scenario: Display upgradable candidate versions when none is specified and none is in use
     Given the candidate "grails" does not exist locally
     And the system is bootstrapped
-    When I enter "sdk outdated"
+    When I enter "sdk upgrade"
     Then I see "No candidates are in use"
 
-  Scenario: Display outdated candidate versions when none is specified and one is in use
+  Scenario: Display upgradable candidate versions when none is specified and one is in use
     Given the candidate "grails" version "1.3.9" is already installed and default
     And the default "grails" version is "2.4.4"
     And the system is bootstrapped
-    When I enter "sdk outdated"
-    Then I see "Outdated:"
+    When I enter "sdk upgrade"
+    Then I see "Upgrade:"
     And I see "grails (1.3.9 < 2.4.4)"
 
-  Scenario: Display outdated candidate versions when none is specified and multiple are in use
+  Scenario: Display upgradable candidate versions when none is specified and multiple are in use
     Given  the candidate "grails" version "1.3.9" is already installed and default
     And the default "grails" version is "2.4.4"
     And the candidate "groovy" version "2.0.5" is already installed and default
     And the default "groovy" version is "2.4.1"
     And the system is bootstrapped
-    When I enter "sdk outdated"
-    Then I see "Outdated:"
+    When I enter "sdk upgrade"
+    Then I see "Upgrade:"
     And I see "grails (1.3.9 < 2.4.4)"
     And I see "groovy (2.0.5 < 2.4.1)"
 
-  Scenario: Display outdated candidate versions when none specified and multiple in use but not outdated
+  Scenario: Display upgradable candidate versions when none specified and multiple in use but not upgradable
     Given  the candidate "grails" version "1.3.9" is already installed and default
     And the default "grails" version is "1.3.9"
     And the candidate "groovy" version "2.0.5" is already installed and default
     And the default "groovy" version is "2.0.5"
     And the system is bootstrapped
-    When I enter "sdk outdated"
+    When I enter "sdk upgrade"
     Then I see "All candidates are up-to-date"
 
-  Scenario: Update all outdated candidates versions and set them as default
+  Scenario: Update all upgradable candidates versions and set them as default
     Given the candidate "grails" version "1.3.9" is already installed and default
     And the default "grails" version is "2.1.0"
     And the candidate "grails" version "2.1.0" is available for download
     And the system is bootstrapped
-    When I enter "sdk outdated" and answer "Y"
-    Then I see "Outdated:"
+    When I enter "sdk upgrade" and answer "Y"
+    Then I see "Upgrade:"
     And I see "grails (1.3.9 < 2.1.0)"
-    And I see "Update candidate(s) and set latest version(s) as default? (Y/n)"
+    And I see "Upgrade candidate(s) and set latest version(s) as default? (Y/n)"
     And I do not see "Do you want grails 2.1.0 to be set as default? (Y/n)"
     And I see "Setting grails 2.1.0 as default."
     Then the candidate "grails" version "2.1.0" should be the default
 
-  Scenario: Don't update all outdated candidates versions and set them as default
+  Scenario: Don't update all upgradable candidates versions and set them as default
     Given the candidate "grails" version "1.3.9" is already installed and default
     And the default "grails" version is "2.1.0"
     And the candidate "grails" version "2.1.0" is available for download
     And the system is bootstrapped
-    When I enter "sdk outdated" and answer "N"
-    Then I see "Outdated:"
+    When I enter "sdk upgrade" and answer "N"
+    Then I see "Upgrade:"
     And I see "grails (1.3.9 < 2.1.0)"
-    And I see "Update candidate(s) and set latest version(s) as default? (Y/n)"
+    And I see "Upgrade candidate(s) and set latest version(s) as default? (Y/n)"
     Then the candidate "grails" version "1.3.9" should be the default
 
-  Scenario: Update outdated candidate version and set it as default
+  Scenario: Update upgradable candidate version and set it as default
     Given the candidate "grails" version "1.3.9" is already installed and default
     And the default "grails" version is "2.1.0"
     And the candidate "grails" version "2.1.0" is available for download
     And the system is bootstrapped
-    When I enter "sdk outdated grails" and answer "Y"
-    Then I see "Outdated:"
+    When I enter "sdk upgrade grails" and answer "Y"
+    Then I see "Upgrade:"
     And I see "grails (1.3.9 < 2.1.0)"
-    And I see "Update candidate(s) and set latest version(s) as default? (Y/n): "
+    And I see "Upgrade candidate(s) and set latest version(s) as default? (Y/n): "
     And I do not see "Do you want grails 2.1.0 to be set as default? (Y/n)"
     And I see "Setting grails 2.1.0 as default."
     Then the candidate "grails" version "2.1.0" should be the default
 
-  Scenario: Don't update outdated candidate version and set it as default
+  Scenario: Don't update upgradable candidate version and set it as default
     Given the candidate "grails" version "1.3.9" is already installed and default
     And the default "grails" version is "2.1.0"
     And the candidate "grails" version "2.1.0" is available for download
     And the system is bootstrapped
-    When I enter "sdk outdated grails" and answer "N"
-    Then I see "Outdated:"
+    When I enter "sdk upgrade grails" and answer "N"
+    Then I see "Upgrade:"
     And I see "grails (1.3.9 < 2.1.0)"
-    And I see "Update candidate(s) and set latest version(s) as default? (Y/n)"
+    And I see "Upgrade candidate(s) and set latest version(s) as default? (Y/n)"
     Then the candidate "grails" version "1.3.9" should be the default


### PR DESCRIPTION
Attempt to rename `outdated` command to `upgrade`. I've made two commits to ease the review:
1. 4dda1bf4f52f8138b449a48ed8538c99d719818e Actual command renaming
2. 8b9138268eecb6671ce109fc0ac3494674444f95 Renaming files containing `outdated`

Since mnemonic `u` is already used by the `use` command, I've proposed `g` as the mnemonic for `upgrade`.
I've kept backwards compatibility for `outdated` command and its mnemonic `o`.

*Edit:* Finally `upgrade` mnemonic has been set to `ug`