### PR TITLE
Revert "Fix IFS backup bug."

### DIFF
--- a/src/main/bash/sdkman-init.sh
+++ b/src/main/bash/sdkman-init.sh
@@ -106,9 +106,10 @@ else
 fi
 
 # Set the candidate array
+OLD_IFS="$IFS"
 IFS=","
 SDKMAN_CANDIDATES=(${SDKMAN_CANDIDATES_CSV})
-unset IFS
+IFS="$OLD_IFS"
 
 # determine if up to date
 SDKMAN_VERSION_FILE="${SDKMAN_DIR}/var/version"


### PR DESCRIPTION
This reverts commit 05bb6d4c4a5da466b94ed1a01dedcfd0746a357a.

Changing the $IFS causes issues on some systems:
"Yesterday I updated sdkman to 5.3.0+159, and now I can not login to
OS (ubuntu 16.10)"