### PR TITLE
fix for issue #518

### DIFF
--- a/src/main/bash/sdkman-install.sh
+++ b/src/main/bash/sdkman-install.sh
@@ -125,6 +125,12 @@ function __sdkman_download {
 
 		#download binary
 		__sdkman_secure_curl_download "$download_url" > "$binary_input"
+		local download_exit=$?
+		if [ $download_exit -ne 0 ]; then
+			echo ""
+			__sdkman_echo_red "Failed to download ${candidate} from $download_url"
+			return 1
+		fi
 		__sdkman_echo_debug "Downloaded binary to: $binary_input"
 
 		#post-installation hook: implements function __sdkman_post_installation_hook

--- a/src/main/bash/sdkman-utils.sh
+++ b/src/main/bash/sdkman-utils.sh
@@ -43,7 +43,10 @@ function __sdkman_secure_curl_download {
 		curl_params="$curl_params --cookie $cookie"
 	fi
 
-	curl ${curl_params} "$1"
+	# credit to http://superuser.com/questions/272265/getting-curl-to-output-http-status-code/862395#862395
+	exec 3>&1
+	local http_status=$(curl -w "%{http_code}" -o >(cat >&3) ${curl_params} "$1")
+	if [[ $http_status == 2* ]]; then return 0; else return 1; fi
 }
 
 function __sdkman_secure_curl_with_timeouts {


### PR DESCRIPTION
curl download function now returns 0 if http status code is in 2xx family and 1 otherwise; install function now checks download status and exits early with appropriate message if download failed