### PR TITLE
Update SDKMAN_VERSION after selfupdate

### DIFF
--- a/src/main/bash/sdkman-selfupdate.sh
+++ b/src/main/bash/sdkman-selfupdate.sh
@@ -30,6 +30,7 @@ function __sdk_selfupdate {
 		export sdkman_debug_mode
 		export sdkman_beta_channel
 		__sdkman_secure_curl "${SDKMAN_LEGACY_API}/selfupdate?beta=${sdkman_beta_channel}" | bash
+		SDKMAN_VERSION=$(cat "$SDKMAN_VERSION_FILE")
 	fi
 	unset SDKMAN_FORCE_SELFUPDATE
 }


### PR DESCRIPTION
After running `selfupdate` the `.sdkman/var/version` file holds the latest version but `SDKMAN_VERSION` environment variable is not updated accordingly. This PR aims to fix that.

I've tried to add a test for it but I've run into a couple of issues:
1. I don't know how `@manual` annotated tests are supposed to be run
2. The kind of test I tried to do I think it's not supported by the current BDD approach:
```
  Scenario: Selfupdate updates version environment variable
    Given an outdated initialised environment
    And the system is bootstrapped
    When I enter "sdk version"
    And I enter "sdk selfupdate"
    And I enter "sdk version"
    Then I see "SDKMAN 4.0.0"
    And I see "Updating SDKMAN..."
    And I see "Successfully upgraded SDKMAN."
    And I see "SDKMAN 5.0.0"
```
Since I'm running more than one command I guess assertions can only access the latest echoed info.

Please let me know if I can add a test somehow.