### PR TITLE
Fix linking in windows bash environment

### DIFF
--- a/src/main/bash/sdkman-path-helpers.sh
+++ b/src/main/bash/sdkman-path-helpers.sh
@@ -82,7 +82,7 @@ function __sdkman_link_candidate_version {
 
 	# Change the 'current' symlink for the candidate, hence affecting all shells.
 	if [[ -h "${SDKMAN_CANDIDATES_DIR}/${candidate}/current" || -d "${SDKMAN_CANDIDATES_DIR}/${candidate}/current" ]]; then
-		rm -f "${SDKMAN_CANDIDATES_DIR}/${candidate}/current"
+		rm -fr "${SDKMAN_CANDIDATES_DIR}/${candidate}/current"
 	fi
 	ln -s "${SDKMAN_CANDIDATES_DIR}/${candidate}/${version}" "${SDKMAN_CANDIDATES_DIR}/${candidate}/current"
 }


### PR DESCRIPTION
In windows the link command simply creates a copy of the directory and hence the removal of the directory fails without the `-r` flag