### PR TITLE
Make upgrade command bash/zsh compatible

### DIFF
--- a/src/main/bash/sdkman-upgrade.sh
+++ b/src/main/bash/sdkman-upgrade.sh
@@ -23,7 +23,11 @@ function __sdk_upgrade {
 		candidates=$1
 	else
 		all=true
-		candidates=${SDKMAN_CANDIDATES[@]}
+		if [[ "$zsh_shell" == 'true' ]]; then
+			candidates=( ${SDKMAN_CANDIDATES[@]} )
+		else
+			candidates=${SDKMAN_CANDIDATES[@]}
+		fi
 	fi
 	installed_count=0
 	upgradable_count=0


### PR DESCRIPTION
The `upgrade` command doesn't work properly in `zsh` due to the different nature on array assignations.

I couldn't find a more elegant way to do it. This is the only place in the whole codebase where the `SDKMAN_CANDIDATES` array is not directly accessed but assigned to a local variable (in order to reuse the upgrade code for the single candidate vs. all candidates scenarios).