### PR TITLE
Fix #562: Use /usr/bin/env bash for the shebang

### DIFF
--- a/bin/build_drone.sh
+++ b/bin/build_drone.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 RELEASE=$(grep 'sdkmanVersion' config.groovy | sed 's_sdkmanVersion = __g' | tr -d "'")
 

--- a/bin/build_travis.sh
+++ b/bin/build_travis.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./gradlew -Penv=production clean test assemble

--- a/bin/download.sh
+++ b/bin/download.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CANDIDATE="$1"
 VERSION="$2"

--- a/bin/release-binary.sh
+++ b/bin/release-binary.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 BRANCH="$1"
 BUILD_NUMBER="$2"

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 VERSION="$1"
 BRANCH="production"

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -z $(which java) ]; then
 	echo "Please install java before continuing..."

--- a/src/main/bash/sdkman-availability.sh
+++ b/src/main/bash/sdkman-availability.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 #   Copyright 2012 Marco Vermeulen

--- a/src/main/bash/sdkman-broadcast.sh
+++ b/src/main/bash/sdkman-broadcast.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 #   Copyright 2012 Marco Vermeulen

--- a/src/main/bash/sdkman-current.sh
+++ b/src/main/bash/sdkman-current.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 #   Copyright 2012 Marco Vermeulen

--- a/src/main/bash/sdkman-default.sh
+++ b/src/main/bash/sdkman-default.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 #   Copyright 2012 Marco Vermeulen

--- a/src/main/bash/sdkman-env-helpers.sh
+++ b/src/main/bash/sdkman-env-helpers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 #   Copyright 2012 Marco Vermeulen

--- a/src/main/bash/sdkman-flush.sh
+++ b/src/main/bash/sdkman-flush.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 #   Copyright 2012 Marco Vermeulen

--- a/src/main/bash/sdkman-help.sh
+++ b/src/main/bash/sdkman-help.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 #   Copyright 2012 Marco Vermeulen

--- a/src/main/bash/sdkman-init.sh
+++ b/src/main/bash/sdkman-init.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 #   Copyright 2012 Marco Vermeulen

--- a/src/main/bash/sdkman-install.sh
+++ b/src/main/bash/sdkman-install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 #   Copyright 2012 Marco Vermeulen

--- a/src/main/bash/sdkman-list.sh
+++ b/src/main/bash/sdkman-list.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 #   Copyright 2012 Marco Vermeulen

--- a/src/main/bash/sdkman-main.sh
+++ b/src/main/bash/sdkman-main.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 #   Copyright 2012 Marco Vermeulen

--- a/src/main/bash/sdkman-offline.sh
+++ b/src/main/bash/sdkman-offline.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 #   Copyright 2012 Marco Vermeulen

--- a/src/main/bash/sdkman-path-helpers.sh
+++ b/src/main/bash/sdkman-path-helpers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 #   Copyright 2012 Marco Vermeulen

--- a/src/main/bash/sdkman-selfupdate.sh
+++ b/src/main/bash/sdkman-selfupdate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 #   Copyright 2012 Marco Vermeulen

--- a/src/main/bash/sdkman-uninstall.sh
+++ b/src/main/bash/sdkman-uninstall.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 #   Copyright 2012 Marco Vermeulen

--- a/src/main/bash/sdkman-upgrade.sh
+++ b/src/main/bash/sdkman-upgrade.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 #   Copyright 2012 Marco Vermeulen

--- a/src/main/bash/sdkman-use.sh
+++ b/src/main/bash/sdkman-use.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 #   Copyright 2012 Marco Vermeulen

--- a/src/main/bash/sdkman-utils.sh
+++ b/src/main/bash/sdkman-utils.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 #   Copyright 2012 Marco Vermeulen

--- a/src/main/bash/sdkman-version.sh
+++ b/src/main/bash/sdkman-version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 #   Copyright 2012 Marco Vermeulen

--- a/src/test/groovy/sdkman/stubs/CurlStub.groovy
+++ b/src/test/groovy/sdkman/stubs/CurlStub.groovy
@@ -10,7 +10,7 @@ class CurlStub {
 
         def file = new File(folder, "curl")
         file.createNewFile()
-        file.write "#!/bin/bash\n"
+        file.write "#!/usr/bin/env bash\n"
         file.executable = true
 
         new CurlStub(file:file)

--- a/src/test/groovy/sdkman/stubs/HookResponses.groovy
+++ b/src/test/groovy/sdkman/stubs/HookResponses.groovy
@@ -3,7 +3,7 @@ package sdkman.stubs
 class HookResponses {
     static preInstallationHookSuccess() {
         '''
-#!/bin/bash
+#!/usr/bin/env bash
 function __sdkman_pre_installation_hook {
     echo "Pre-installation hook success"
     return 0
@@ -12,7 +12,7 @@ function __sdkman_pre_installation_hook {
 
     static preInstallationHookFailure() {
         '''
-#!/bin/bash
+#!/usr/bin/env bash
 function __sdkman_pre_installation_hook {
     echo "Pre-installation hook failure"
     return 1
@@ -21,7 +21,7 @@ function __sdkman_pre_installation_hook {
 
     static postInstallationHookSuccess() {
         '''
-#!/bin/bash
+#!/usr/bin/env bash
 function __sdkman_post_installation_hook {
     mv $binary_input $zip_output
     echo "Post-installation hook success"
@@ -31,7 +31,7 @@ function __sdkman_post_installation_hook {
 
     static postInstallationHookFailure() {
         '''
-#!/bin/bash
+#!/usr/bin/env bash
 function __sdkman_post_installation_hook {
     echo "Post-installation hook failure"
     return 1

--- a/src/test/groovy/sdkman/stubs/UnameStub.groovy
+++ b/src/test/groovy/sdkman/stubs/UnameStub.groovy
@@ -10,7 +10,7 @@ class UnameStub {
 
         def file = new File(folder, "uname")
         file.createNewFile()
-        file.write "#!/bin/bash\n"
+        file.write "#!/usr/bin/env bash\n"
         file.executable = true
 
         new UnameStub(file:file)

--- a/src/test/resources/__files/hooks/post_hook_java_8u101_linux64.sh
+++ b/src/test/resources/__files/hooks/post_hook_java_8u101_linux64.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 function __sdkman_post_installation_hook {
     echo "Download has failed, aborting!"
     echo ""

--- a/src/test/resources/__files/hooks/post_hook_java_8u111_linux64.sh
+++ b/src/test/resources/__files/hooks/post_hook_java_8u111_linux64.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 function __sdkman_post_installation_hook {
     echo "Inside post-install hook..."
     mkdir -p "$SDKMAN_DIR/tmp/out"

--- a/src/test/resources/__files/hooks/post_hook_java_8u111_universal.sh
+++ b/src/test/resources/__files/hooks/post_hook_java_8u111_universal.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 function __sdkman_post_installation_hook {
     mv "$binary_input" "$zip_output"
 }

--- a/src/test/resources/__files/hooks/pre_hook_java_8u101_linux64.sh
+++ b/src/test/resources/__files/hooks/pre_hook_java_8u101_linux64.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 function __sdkman_pre_installation_hook {
     echo -n "Do you agree to the terms of this agreement? (Y/n)"
     read agree

--- a/src/test/resources/__files/hooks/pre_hook_java_8u111_linux64.sh
+++ b/src/test/resources/__files/hooks/pre_hook_java_8u111_linux64.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 function __sdkman_pre_installation_hook {
     echo "Inside pre-install hook..."
     cookie="$SDKMAN_DIR/var/cookie"

--- a/src/test/resources/__files/hooks/pre_hook_java_8u92_linux64.sh
+++ b/src/test/resources/__files/hooks/pre_hook_java_8u92_linux64.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 function __sdkman_pre_installation_hook {
     echo "Oracle requires that you agree with the Oracle Binary Code License Agreement"
     echo "prior to installation. The license agreement can be found at:"


### PR DESCRIPTION
/bin/bash will not work on OSes which do not have bash as default shell, e.g.,
*BSD. Use common env with bash from PATH to launch scripts.