### PR TITLE
Properly evaluate command from PAGER string

### DIFF
--- a/src/main/bash/sdkman-utils.sh
+++ b/src/main/bash/sdkman-utils.sh
@@ -60,7 +60,7 @@ function __sdkman_secure_curl_with_timeouts {
 
 function __sdkman_page {
 	if [[ -n "$PAGER" ]]; then
-		"$@" | $PAGER
+		"$@" | eval $PAGER
 	elif command -v less >& /dev/null; then
 		"$@" | less
 	else


### PR DESCRIPTION
PAGER may contain arguments.  See `man 1 man` for details.  See `man bash` for the explanation of `eval`.

This addresses Issue #594 
