### PR TITLE
Refine bash major version check

### DIFF
--- a/src/main/bash/sdkman-utils.sh
+++ b/src/main/bash/sdkman-utils.sh
@@ -105,12 +105,12 @@ function __sdkman_echo_confirm {
 }
 
 function __sdkman_legacy_bash_message {
-    if [[ "$bash_shell" == 'true' && -z "$(bash --version | grep 'GNU bash, version 4..*')" ]]; then
+    if [[ "$bash_shell" == 'true' && "$BASH_VERSINFO" -lt 4 ]]; then
         __sdkman_echo_red "An outdated version of bash was detected on your system!"
         echo ""
         __sdkman_echo_red "We recommend upgrading to bash 4.x, you have:"
         echo ""
-        __sdkman_echo_yellow "  $(bash --version | grep 'GNU bash, version')"
+        __sdkman_echo_yellow "  $(bash --version | head -n1)"
         echo ""
     fi
 }


### PR DESCRIPTION
The previous bash version check, `bash --version | grep ... `, may not work when the output is not in English (for example, it didn't work when the output was in Italian). 

For the same reason, I've modified also the line 113, to output the first command output of `bash --version` without checking for the content.

This addresses Issue #649
