### PR TITLE
add -r for removing older dir

### DIFF
--- a/src/main/bash/sdkman-path-helpers.sh
+++ b/src/main/bash/sdkman-path-helpers.sh
@@ -82,7 +82,7 @@ function __sdkman_link_candidate_version {
 
 	# Change the 'current' symlink for the candidate, hence affecting all shells.
 	if [[ -h "${SDKMAN_CANDIDATES_DIR}/${candidate}/current" || -d "${SDKMAN_CANDIDATES_DIR}/${candidate}/current" ]]; then
-		rm -f "${SDKMAN_CANDIDATES_DIR}/${candidate}/current"
+		rm -rf "${SDKMAN_CANDIDATES_DIR}/${candidate}/current"
 	fi
 	ln -s "${SDKMAN_CANDIDATES_DIR}/${candidate}/${version}" "${SDKMAN_CANDIDATES_DIR}/${candidate}/current"
 }


### PR DESCRIPTION
Hi, I'm very pleasure using this tool, and I'm executing 'sdk upgrade', system prompts the new version of gradle, but when finish installing new version, it can't remove older version, and I found problem about removing, so I add '-r' to resolving this bug. Tks!
