### PR TITLE
Validate Version on Local Install

### DIFF
--- a/src/main/bash/sdkman-install.sh
+++ b/src/main/bash/sdkman-install.sh
@@ -77,11 +77,21 @@ function __sdkman_install_candidate_version {
 }
 
 function __sdkman_install_local_version {
-	local candidate version folder
+	local candidate version folder version_length version_length_max
+
+	version_length_max=15
 
 	candidate="$1"
 	version="$2"
 	folder="$3"
+
+	#Validate max length of version
+	version_length=${#version}
+
+	if [[ $version_length > $version_length_max ]]; then
+		__sdkman_echo_red "Invalid version! ${version} with length ${version_length} exceeds max of ${version_length_max}!"
+		return 1
+	fi
 
 	mkdir -p "${SDKMAN_CANDIDATES_DIR}/${candidate}"
 
@@ -97,6 +107,7 @@ function __sdkman_install_local_version {
 
 	else
 		__sdkman_echo_red "Invalid path! Refusing to link ${candidate} ${version} to ${folder}."
+		return 1
 	fi
 
 	echo ""

--- a/src/test/cucumber/local_developement_versions.feature
+++ b/src/test/cucumber/local_developement_versions.feature
@@ -65,3 +65,11 @@ Feature: Local Development Versions
     When I enter "sdk install groovy 2.1-SNAPSHOT /some/bogus/path/to/groovy"
     Then I see "Invalid path! Refusing to link groovy 2.1-SNAPSHOT to /some/bogus/path/to/groovy."
     And the candidate "groovy" version "2.1-SNAPSHOT" is not installed
+
+  Scenario: Prevent installation of a local development version for an invalid version
+    Given the candidate "groovy" version "2.1-SNAPSHOT-LONG" is not available for download
+    And I have a local candidate "groovy" version "2.1-SNAPSHOT-LONG" at relative path "some/relative/path/to/groovy"
+    And the system is bootstrapped
+    When I enter "sdk install groovy 2.1-SNAPSHOT-LONG some/relative/path/to/groovy"
+    Then I see "Invalid version! 2.1-SNAPSHOT-LONG with length 17 exceeds max of 15!"
+    And the candidate "groovy" version "2.1-SNAPSHOT-LONG" is not installed


### PR DESCRIPTION
For installing local development versions validate the length doesn't exceed 15 char which will end up being truncated in the list view.

This Addresses Issue #619
- [x] a conversation was held in the appropriate Gitter Room.
- [X] a Github Issue was opened for this feature / bug.
- [X] test coverage was added (Cucumber or Spock as appropriate).

