### PR TITLE
Return non-zero exit code on failure

### DIFF
--- a/src/main/bash/sdkman-main.sh
+++ b/src/main/bash/sdkman-main.sh
@@ -115,14 +115,19 @@ function sdk {
 	# hence the name conversion as the first step here.
 	CONVERTED_CMD_NAME=$(echo "$COMMAND" | tr '-' '_')
 
+	# Store the return code of the requested command
+	local final_rc=0
+
 	# Execute the requested command
 	if [ -n "$CMD_FOUND" ]; then
 		# It's available as a shell function
 		__sdk_"$CONVERTED_CMD_NAME" "$QUALIFIER" "$3" "$4"
+		final_rc=$?
 	fi
 
 	# Attempt upgrade after all is done
 	if [[ "$COMMAND" != "selfupdate" ]]; then
 		__sdkman_auto_update "$SDKMAN_REMOTE_VERSION" "$SDKMAN_VERSION"
 	fi
+	return $final_rc
 }

--- a/src/test/cucumber/install_candidate.feature
+++ b/src/test/cucumber/install_candidate.feature
@@ -26,6 +26,7 @@ Feature: Install Candidate
     And the candidate "grails" version "1.4.4" is not available for download
     When I enter "sdk install grails 1.4.4"
     Then I see "Stop! grails 1.4.4 is not available."
+    And the exit code is 1
 
   Scenario: Install a Candidate version that is already installed
     Given the system is bootstrapped

--- a/src/test/groovy/sdkman/steps/installation_steps.groovy
+++ b/src/test/groovy/sdkman/steps/installation_steps.groovy
@@ -97,3 +97,7 @@ And(~/^the cookie has been removed$/) { ->
     def cookie = new File("$sdkmanDir/var/cookie")
     assert !cookie.exists()
 }
+
+And(~/^the exit code is (\d+)$/) { Integer rc ->
+    assert bash.getStatus() == rc
+}


### PR DESCRIPTION
Failed installations should return an appropriate error code to
indicate in some way to the shell (other than just stdout) that
something went wrong.

To raise a new Pull Request, the following prerequisites need to be met. Please tick before proceeding:

- [X] a conversation was held in the appropriate Gitter Room.
- [X] a Github Issue was opened for this feature / bug.
- [X] test coverage was added (Cucumber or Spock as appropriate).

This addresses Issue #665 