### PR TITLE
download with retry

### DIFF
--- a/src/main/bash/sdkman-init.sh
+++ b/src/main/bash/sdkman-init.sh
@@ -105,7 +105,7 @@ if [[ -z "${sdkman_curl_retry}" ]]; then sdkman_curl_retry=0; fi
 if [[ -z "${sdkman_curl_retry_max_time}" ]]; then sdkman_curl_retry_max_time=60; fi
 
 # set curl to continue downloading automatically
-if [[ -z "${sdkman_curl_continue_automatically}" ]]; then sdkman_curl_continue_automatically=true; fi
+if [[ -z "${sdkman_curl_continue}" ]]; then sdkman_curl_continue=true; fi
 
 # Read list of candidates and set array
 SDKMAN_CANDIDATES_CACHE="${SDKMAN_DIR}/var/candidates"

--- a/src/main/bash/sdkman-init.sh
+++ b/src/main/bash/sdkman-init.sh
@@ -98,6 +98,15 @@ fi
 if [[ -z "$sdkman_curl_connect_timeout" ]]; then sdkman_curl_connect_timeout=7; fi
 if [[ -z "$sdkman_curl_max_time" ]]; then sdkman_curl_max_time=10; fi
 
+# set curl retry
+if [[ -z "${sdkman_curl_retry}" ]]; then sdkman_curl_retry=0; fi
+
+# set curl retry max time in seconds
+if [[ -z "${sdkman_curl_retry_max_time}" ]]; then sdkman_curl_retry_max_time=60; fi
+
+# set curl to continue downloading automatically
+if [[ -z "${sdkman_curl_continue_automatically}" ]]; then sdkman_curl_continue_automatically=true; fi
+
 # Read list of candidates and set array
 SDKMAN_CANDIDATES_CACHE="${SDKMAN_DIR}/var/candidates"
 SDKMAN_CANDIDATES_CSV=$(<"$SDKMAN_CANDIDATES_CACHE")

--- a/src/main/bash/sdkman-install.sh
+++ b/src/main/bash/sdkman-install.sh
@@ -147,8 +147,8 @@ function __sdkman_download {
 		echo ""
 
 		#download binary
-		__sdkman_secure_curl_download "$download_url" > "$binary_input"
-		__sdkman_echo_debug "Downloaded binary to: $binary_input"
+		__sdkman_secure_curl_download "${download_url}" --output "${binary_input}"
+		__sdkman_echo_debug "Downloaded binary to: ${binary_input}"
 
 		#post-installation hook: implements function __sdkman_post_installation_hook
 		#responsible for taking `binary_input` and producing `zip_output`

--- a/src/main/bash/sdkman-utils.sh
+++ b/src/main/bash/sdkman-utils.sh
@@ -51,7 +51,7 @@ function __sdkman_secure_curl_download {
 		curl_params="--retry-max-time ${sdkman_curl_retry_max_time} ${curl_params}"
 	fi
 
-	if [[ "${sdkman_curl_continue_automatically}" == 'true' ]]; then
+	if [[ "${sdkman_curl_continue}" == 'true' ]]; then
 		curl_params="-C - ${curl_params}"
 	fi
 

--- a/src/main/bash/sdkman-utils.sh
+++ b/src/main/bash/sdkman-utils.sh
@@ -43,10 +43,22 @@ function __sdkman_secure_curl_download {
 		curl_params="$curl_params --cookie $cookie"
 	fi
 
+	if [[ ! -z "${sdkman_curl_retry}" ]]; then
+		curl_params="--retry ${sdkman_curl_retry} ${curl_params}"
+	fi
+
+	if [[ ! -z "${sdkman_curl_retry_max_time}" ]]; then
+		curl_params="--retry-max-time ${sdkman_curl_retry_max_time} ${curl_params}"
+	fi
+
+	if [[ "${sdkman_curl_continue_automatically}" == 'true' ]]; then
+		curl_params="-C - ${curl_params}"
+	fi
+
 	if [[ "$zsh_shell" == 'true' ]]; then
-		curl ${=curl_params} "$1"
+		curl ${=curl_params} "$@"
 	else
-		curl ${curl_params} "$1"
+		curl ${curl_params} "$@"
 	fi
 }
 


### PR DESCRIPTION
support `curl` options related to retry which might be useful in poor network connection conditions.

This addresses Issue #632
