### PR TITLE
Use '>|' to write var/ status files

### DIFF
--- a/src/main/bash/sdkman-availability.sh
+++ b/src/main/bash/sdkman-availability.sh
@@ -85,10 +85,10 @@ function __sdkman_update_broadcast {
 	if [[ "$SDKMAN_AVAILABLE" == "true" && "$broadcast_live_id" != "$broadcast_old_id" && "$COMMAND" != "selfupdate" && "$COMMAND" != "flush" ]]; then
 		mkdir -p "${SDKMAN_DIR}/var"
 
-		echo "$broadcast_live_id" >| "$broadcast_id_file"
+		echo "$broadcast_live_id" | tee "$broadcast_id_file" > /dev/null
 
 		BROADCAST_LIVE_TEXT=$(__sdkman_secure_curl "${SDKMAN_CANDIDATES_API}/broadcast/latest")
-		echo "$BROADCAST_LIVE_TEXT" >| "$broadcast_text_file"
+		echo "$BROADCAST_LIVE_TEXT" | tee "$broadcast_text_file" > /dev/null
 		if [[ "$COMMAND" != "broadcast" ]]; then
 			__sdkman_echo_cyan "$BROADCAST_LIVE_TEXT"
 		fi

--- a/src/main/bash/sdkman-availability.sh
+++ b/src/main/bash/sdkman-availability.sh
@@ -85,10 +85,10 @@ function __sdkman_update_broadcast {
 	if [[ "$SDKMAN_AVAILABLE" == "true" && "$broadcast_live_id" != "$broadcast_old_id" && "$COMMAND" != "selfupdate" && "$COMMAND" != "flush" ]]; then
 		mkdir -p "${SDKMAN_DIR}/var"
 
-		echo "$broadcast_live_id" > "$broadcast_id_file"
+		echo "$broadcast_live_id" >| "$broadcast_id_file"
 
 		BROADCAST_LIVE_TEXT=$(__sdkman_secure_curl "${SDKMAN_CANDIDATES_API}/broadcast/latest")
-		echo "$BROADCAST_LIVE_TEXT" > "$broadcast_text_file"
+		echo "$BROADCAST_LIVE_TEXT" >| "$broadcast_text_file"
 		if [[ "$COMMAND" != "broadcast" ]]; then
 			__sdkman_echo_cyan "$BROADCAST_LIVE_TEXT"
 		fi

--- a/src/main/bash/sdkman-cache.sh
+++ b/src/main/bash/sdkman-cache.sh
@@ -61,7 +61,7 @@ function ___sdkman_check_version_cache {
 
 		else
 			__sdkman_echo_debug "Overwriting version cache with: $SDKMAN_REMOTE_VERSION"
-			echo "${SDKMAN_REMOTE_VERSION}" >| "$version_file"
+			echo "${SDKMAN_REMOTE_VERSION}" | tee "$version_file" > /dev/null
 		fi
 	fi
 

--- a/src/main/bash/sdkman-cache.sh
+++ b/src/main/bash/sdkman-cache.sh
@@ -61,7 +61,7 @@ function ___sdkman_check_version_cache {
 
 		else
 			__sdkman_echo_debug "Overwriting version cache with: $SDKMAN_REMOTE_VERSION"
-			echo "${SDKMAN_REMOTE_VERSION}" > "$version_file"
+			echo "${SDKMAN_REMOTE_VERSION}" >| "$version_file"
 		fi
 	fi
 


### PR DESCRIPTION
Setting 'noclobber' in bash or zsh prevents writing to an existing
regular file when using > as redirecting operator. Setting 'noclobber' allows
users of interactive shells to prevent accidential overwriting of
existing files.

bash and zsh allow to use >| as redirection operator so that the
redirection is attempted.

Because the write to the status files is required and not by accident
the >| is used in those cases.

To raise a new Pull Request, the following prerequisites need to be met. Please tick before proceeding:

- [x] a conversation was held in the appropriate Gitter Room.
- [x] a Github Issue was opened for this feature / bug.
- [ ] test coverage was added (Cucumber or Spock as appropriate).

This addresses Issue #669 
