### PR TITLE
prevent "unbound variable" errors when -u (nounset) bash option is in use

### DIFF
--- a/src/main/bash/sdkman-init.sh
+++ b/src/main/bash/sdkman-init.sh
@@ -17,15 +17,15 @@
 #
 
 # set env vars if not set
-if [ -z "$SDKMAN_VERSION" ]; then
+if [ -z "${SDKMAN_VERSION:-}" ]; then
 	export SDKMAN_VERSION="@SDKMAN_VERSION@"
 fi
 
-if [ -z "$SDKMAN_CANDIDATES_API" ]; then
+if [ -z "${SDKMAN_CANDIDATES_API:-}" ]; then
 	export SDKMAN_CANDIDATES_API="@SDKMAN_CANDIDATES_API@"
 fi
 
-if [ -z "$SDKMAN_DIR" ]; then
+if [ -z "${SDKMAN_DIR:-}" ]; then
 	export SDKMAN_DIR="$HOME/.sdkman"
 fi
 


### PR DESCRIPTION
The documentation encourages the `source`-ing of `.sdkman/bin/sdkman-init.sh`,
so the sourcer will fail if `-u (nounset)` is currently active, and one of
the optional environment variables is not set.

```bash
set -euo pipefail
curl -s "https://get.sdkman.io" | bash
source "${HOME}/.sdkman/bin/sdkman-init.sh"
/root/.sdkman/bin/sdkman-init.sh: line 29: SDKMAN_VERSION: unbound variable 
```

This pull request prevents these unbound variable errors from happening.