### PR TITLE
Reset SDKMAN_DIR if it has wrong owner

### DIFF
--- a/src/main/bash/sdkman-init.sh
+++ b/src/main/bash/sdkman-init.sh
@@ -25,7 +25,7 @@ if [ -z "$SDKMAN_CANDIDATES_API" ]; then
 	export SDKMAN_CANDIDATES_API="@SDKMAN_CANDIDATES_API@"
 fi
 
-if [ -z "$SDKMAN_DIR" ]; then
+if [ -z "$SDKMAN_DIR" ] || [ $(ls -ld "${SDKMAN_DIR}" | awk '{ print $3 }') != $(whoami) ]; then
 	export SDKMAN_DIR="$HOME/.sdkman"
 fi
 


### PR DESCRIPTION
When `su`-ing to another user, environment variables carry over. 
As a result, `sdk` will point to the installation of the original user, 
not the one running the current shell.

Thus: Reset `$SDKMAN_DIR` if the directory it points at
belongs to a user other than the current one.

(Sorry, I didn't have the time to fulfill the prerequisites. I empathize, but that doesn't change my time prioritization.)
