### PR TITLE
Update SDKMAN_VERSION after selfupdate

### DIFF
--- a/src/main/bash/sdkman-selfupdate.sh
+++ b/src/main/bash/sdkman-selfupdate.sh
@@ -30,6 +30,7 @@ function __sdk_selfupdate {
 		export sdkman_debug_mode
 		export sdkman_beta_channel
 		__sdkman_secure_curl "${SDKMAN_CANDIDATES_API}/selfupdate?beta=${sdkman_beta_channel}" | bash
+		export SDKMAN_VERSION="$(cat "${SDKMAN_DIR}"/var/version)"
 	fi
 	unset SDKMAN_FORCE_SELFUPDATE
 }


### PR DESCRIPTION
_Before:_ `sdk version && sdk selfupdate && sdk version` shows the same version twice despite a newer one having been installed in between.

_After:_ Second call prints the new version.