### PR TITLE
PR 2.5: Append parentheses after bash function names

### DIFF
--- a/src/main/bash/sdkman-update.sh
+++ b/src/main/bash/sdkman-update.sh
@@ -16,7 +16,7 @@
 #   limitations under the License.
 #
 
-function __sdk_update {
+function __sdk_update() {
 	local candidates_uri="${SDKMAN_CANDIDATES_API}/candidates/all"
 	__sdkman_echo_debug "Using candidates endpoint: $candidates_uri"
 

--- a/src/main/bash/sdkman-utils.sh
+++ b/src/main/bash/sdkman-utils.sh
@@ -16,13 +16,13 @@
 #   limitations under the License.
 #
 
-function __sdkman_echo_debug {
+function __sdkman_echo_debug() {
 	if [[ "$sdkman_debug_mode" == 'true' ]]; then
 		echo "$1"
 	fi
 }
 
-function __sdkman_secure_curl {
+function __sdkman_secure_curl() {
 	if [[ "${sdkman_insecure_ssl}" == 'true' ]]; then
 		curl --insecure --silent --location "$1"
 	else
@@ -30,7 +30,7 @@ function __sdkman_secure_curl {
 	fi
 }
 
-function __sdkman_secure_curl_download {
+function __sdkman_secure_curl_download() {
 	local curl_params="--progress-bar --location"
 	if [[ "${sdkman_insecure_ssl}" == 'true' ]]; then
 		curl_params="$curl_params --insecure"
@@ -59,7 +59,7 @@ function __sdkman_secure_curl_download {
 	fi
 }
 
-function __sdkman_secure_curl_with_timeouts {
+function __sdkman_secure_curl_with_timeouts() {
 	if [[ "${sdkman_insecure_ssl}" == 'true' ]]; then
 		curl --insecure --silent --location --connect-timeout ${sdkman_curl_connect_timeout} --max-time ${sdkman_curl_max_time} "$1"
 	else
@@ -67,7 +67,7 @@ function __sdkman_secure_curl_with_timeouts {
 	fi
 }
 
-function __sdkman_page {
+function __sdkman_page() {
 	if [[ -n "$PAGER" ]]; then
 		"$@" | eval $PAGER
 	elif command -v less >& /dev/null; then
@@ -77,7 +77,7 @@ function __sdkman_page {
 	fi
 }
 
-function __sdkman_echo {
+function __sdkman_echo() {
 	if [[ "$sdkman_colour_enable" == 'false' ]]; then
 		echo -e "$2"
 	else
@@ -85,27 +85,27 @@ function __sdkman_echo {
 	fi
 }
 
-function __sdkman_echo_red {
+function __sdkman_echo_red() {
 	__sdkman_echo "31m" "$1"
 }
 
-function __sdkman_echo_no_colour {
+function __sdkman_echo_no_colour() {
 	echo "$1"
 }
 
-function __sdkman_echo_yellow {
+function __sdkman_echo_yellow() {
 	__sdkman_echo "33m" "$1"
 }
 
-function __sdkman_echo_green {
+function __sdkman_echo_green() {
 	__sdkman_echo "32m" "$1"
 }
 
-function __sdkman_echo_cyan {
+function __sdkman_echo_cyan() {
 	__sdkman_echo "36m" "$1"
 }
 
-function __sdkman_echo_confirm {
+function __sdkman_echo_confirm() {
 	if [[ "$sdkman_colour_enable" == 'false' ]]; then
 		echo -n "$1"
 	else
@@ -113,7 +113,7 @@ function __sdkman_echo_confirm {
 	fi
 }
 
-function __sdkman_legacy_bash_message {
+function __sdkman_legacy_bash_message() {
 	__sdkman_echo_red "An outdated version of bash was detected on your system!"
 	echo ""
 	__sdkman_echo_red "We recommend upgrading to bash 4.x, you have:"


### PR DESCRIPTION
IntelliJ auto-formatting inexplicably failed to append parentheses after
function names in certain bash files.  Fixed this.

- [ ] a conversation was held in the appropriate [SDKMAN Slack](https://slack.sdkman.io) channel.
- [ ] a Github Issue was opened for this feature / bug.
- [ ] test coverage was added (Cucumber or Spock as appropriate).