### PR TITLE
PR 6: Candidate cache update bug

### DIFF
--- a/src/test/cucumber/update.feature
+++ b/src/test/cucumber/update.feature
@@ -30,6 +30,17 @@ Feature: Update
 		Then I see "Removing obsolete candidates(s): activator"
 		And the Candidates cache should contain "groovy,scala"
 
+	Scenario: A new candidate is available and a candidate has been removed
+		And the following candidates are currently available from remote API:
+			| candidate |
+			| groovy    |
+			| kotlin    |
+			| scala     |
+		When I enter "sdk update"
+		Then I see "Removing obsolete candidates(s): activator"
+		And I see "Adding new candidates(s): kotlin"
+		And the Candidates cache should contain "groovy,kotlin,scala"
+
 	Scenario: No new candidate is available
 		And the following candidates are currently available from remote API:
 			| candidate |


### PR DESCRIPTION
In `__sdk_update`, candidates wouldn't be updated if the same number of
candidates were removed & added because detection was solely based on
old vs. new candidate counts.

- [ ] a conversation was held in the appropriate [SDKMAN Slack](https://slack.sdkman.io) channel.
- [ ] a Github Issue was opened for this feature / bug.
- [ ] test coverage was added (Cucumber or Spock as appropriate).