### PR TITLE
746 - upgrade should use auto answer

### DIFF
--- a/src/main/bash/sdkman-upgrade.sh
+++ b/src/main/bash/sdkman-upgrade.sh
@@ -70,8 +70,12 @@ function __sdk_upgrade() {
 
 	if [ ${upgradable_count} -gt 0 ]; then
 		echo ""
-		__sdkman_echo_confirm "Upgrade candidate(s) and set latest version(s) as default? (Y/n): "
-		read UPGRADE_ALL
+		
+		if [[ "$sdkman_auto_answer" != 'true' ]]; then
+			__sdkman_echo_confirm "Upgrade candidate(s) and set latest version(s) as default? (Y/n): "
+			read UPGRADE_ALL
+		fi
+
 		export auto_answer_upgrade='true'
 		if [[ -z "$UPGRADE_ALL" || "$UPGRADE_ALL" == "y" || "$UPGRADE_ALL" == "Y" ]]; then
 			# Using array for bash & zsh compatibility

--- a/src/test/cucumber/upgrade_candidate.feature
+++ b/src/test/cucumber/upgrade_candidate.feature
@@ -104,6 +104,20 @@ Feature: Upgrade Candidate
 		And I see "Setting grails 2.1.0 as default."
 		Then the candidate "grails" version "2.1.0" should be the default
 
+	Scenario: Update upgradable candidate version and auto-answer to make it default
+		Given the candidate "grails" version "1.3.9" is already installed and default
+		And the default "grails" version is "2.1.0"
+		And the candidate "grails" version "2.1.0" is available for download
+		And I have configured "sdkman_auto_answer" to "true"
+		And the system is bootstrapped
+		When I enter "sdk upgrade grails"
+		Then I see "Upgrade:"
+		And I see "grails (1.3.9 < 2.1.0)"
+		And I do not see "Upgrade candidate(s) and set latest version(s) as default? (Y/n): "
+		And I do not see "Do you want grails 2.1.0 to be set as default? (Y/n)"
+		And I see "Setting grails 2.1.0 as default."
+		Then the candidate "grails" version "2.1.0" should be the default
+
 	Scenario: Don't update upgradable candidate version and set it as default
 		Given the candidate "grails" version "1.3.9" is already installed and default
 		And the default "grails" version is "2.1.0"


### PR DESCRIPTION
This PR updates `sdk  upgrade` action to respect `sdkman_auto_answer` setting.

- [x] a conversation was held in the appropriate [SDKMAN Slack](https://slack.sdkman.io) channel.
- [x] a Github Issue was opened for this feature / bug.
- [x] test coverage was added (Cucumber or Spock as appropriate).

This addresses Issue #746
