### PR TITLE
Don't fail redirections if noclobber is set

### DIFF
--- a/src/main/bash/sdkman-install.sh
+++ b/src/main/bash/sdkman-install.sh
@@ -129,7 +129,7 @@ function __sdkman_download() {
 		# pre-installation hook: implements function __sdkman_pre_installation_hook
 		local pre_installation_hook="${SDKMAN_DIR}/tmp/hook_pre_${candidate}_${version}.sh"
 		__sdkman_echo_debug "Get pre-installation hook: ${SDKMAN_CANDIDATES_API}/hooks/pre/${candidate}/${version}/${platform_parameter}"
-		__sdkman_secure_curl "${SDKMAN_CANDIDATES_API}/hooks/pre/${candidate}/${version}/${platform_parameter}" > "$pre_installation_hook"
+		__sdkman_secure_curl "${SDKMAN_CANDIDATES_API}/hooks/pre/${candidate}/${version}/${platform_parameter}" >| "$pre_installation_hook"
 		__sdkman_echo_debug "Copy remote pre-installation hook: $pre_installation_hook"
 		source "$pre_installation_hook"
 		__sdkman_pre_installation_hook || return 1
@@ -152,7 +152,7 @@ function __sdkman_download() {
 		# responsible for taking `binary_input` and producing `zip_output`
 		local post_installation_hook="${SDKMAN_DIR}/tmp/hook_post_${candidate}_${version}.sh"
 		__sdkman_echo_debug "Get post-installation hook: ${SDKMAN_CANDIDATES_API}/hooks/post/${candidate}/${version}/${platform_parameter}"
-		__sdkman_secure_curl "${SDKMAN_CANDIDATES_API}/hooks/post/${candidate}/${version}/${platform_parameter}" > "$post_installation_hook"
+		__sdkman_secure_curl "${SDKMAN_CANDIDATES_API}/hooks/post/${candidate}/${version}/${platform_parameter}" >| "$post_installation_hook"
 		__sdkman_echo_debug "Copy remote post-installation hook: ${post_installation_hook}"
 		source "$post_installation_hook"
 		__sdkman_post_installation_hook || return 1

--- a/src/main/bash/sdkman-update.sh
+++ b/src/main/bash/sdkman-update.sh
@@ -44,7 +44,7 @@ function __sdk_update() {
 		# legacy bash workaround
 		if [[ "$bash_shell" == 'true' && "$BASH_VERSINFO" -lt 4 ]]; then
 			__sdkman_legacy_bash_message
-			echo "$fresh_candidates_csv" > "$SDKMAN_CANDIDATES_CACHE"
+			echo "$fresh_candidates_csv" >| "$SDKMAN_CANDIDATES_CACHE"
 			return 0
 		fi
 
@@ -56,13 +56,13 @@ function __sdk_update() {
 		if (( fresh_candidates_length > cached_candidates_length )); then
 			echo ""
 			__sdkman_echo_green "Adding new candidates(s): $diff_candidates"
-			echo "$fresh_candidates_csv" > "$SDKMAN_CANDIDATES_CACHE"
+			echo "$fresh_candidates_csv" >| "$SDKMAN_CANDIDATES_CACHE"
 			echo ""
 			__sdkman_echo_yellow "Please open a new terminal now..."
 		elif (( fresh_candidates_length < cached_candidates_length )); then
 			echo ""
 			__sdkman_echo_green "Removing obsolete candidates(s): $diff_candidates"
-			echo "$fresh_candidates_csv" > "$SDKMAN_CANDIDATES_CACHE"
+			echo "$fresh_candidates_csv" >| "$SDKMAN_CANDIDATES_CACHE"
 			echo ""
 			__sdkman_echo_yellow "Please open a new terminal now..."
 		else

--- a/src/test/groovy/sdkman/env/BashEnv.groovy
+++ b/src/test/groovy/sdkman/env/BashEnv.groovy
@@ -46,7 +46,7 @@ class BashEnv {
 	 * Starts the external bash process.
 	 */
 	void start() {
-		process = ["bash", "--noprofile", "--norc", "-i"].execute(env, workDir)
+		process = ["bash", "--noprofile", "--norc", "-i", "-o", "noclobber"].execute(env, workDir)
 
 		consumeProcessStream(process.inputStream)
 		consumeProcessStream(process.errorStream)


### PR DESCRIPTION
Using the '>|' syntax for shell redirections instead of '>' forces an
overwrite even if the noclobber option is set.

To raise a new Pull Request, the following prerequisites need to be met. Please tick before proceeding:

- [ ] a conversation was held in the appropriate [SDKMAN Slack](https://slack.sdkman.io) channel.
- [x] a Github Issue was opened for this feature / bug.
- [x] test coverage was added (Cucumber or Spock as appropriate).

This addresses Issue #484.

I've added the `-o noclobber` option to the bash test environment and confirmed that without my changes some of the tests fail, while with my changes they all pass. This also prevents regressions in case someone adds another redirection later that doesn't use `>|`.

Since I use zsh myself I can confirm that it works there as well.
