### PR TITLE
Link major version on install

### DIFF
--- a/src/main/bash/sdkman-install.sh
+++ b/src/main/bash/sdkman-install.sh
@@ -72,6 +72,9 @@ function __sdkman_install_candidate_version() {
 	rm -rf "${SDKMAN_DIR}/tmp/out"
 	unzip -oq "${SDKMAN_DIR}/archives/${candidate}-${version}.zip" -d "${SDKMAN_DIR}/tmp/out"
 	mv "$SDKMAN_DIR"/tmp/out/* "${SDKMAN_CANDIDATES_DIR}/${candidate}/${version}"
+ 	major_version="$(echo ${version} | cut -d'.' -f1)"
+ 	__sdkman_echo_green "Linking major version: ${major_version}"
+ 	ln -sf "${SDKMAN_CANDIDATES_DIR}/${candidate}/${version}" "${SDKMAN_CANDIDATES_DIR}/${candidate}/${major_version}"
 	__sdkman_echo_green "Done installing!"
 	echo ""
 }


### PR DESCRIPTION
This addresses Issue #603

I think this should work for other SDKs, but I'm particularly interested in Java versions for IDE support.

The limitation of this PR is that it will override the link without confirmation, but should work in general cases of SDK upgrades. 