### PR TITLE
Add GitHub issue templates for bugs, features, support and PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,18 @@
+---
+name: Bug report
+about: You found a bug in SDKMAN!
+title: "Bug: [A concise title]"
+labels: 'bug'
+assignees: ''
+
+---
+<!-- Thank you for using the SDKMAN! issue tracker! If you are unsure if it is a bug, then consider using the Slack chat before creating a new issue. Please understand, that we cannot offer regular support through GitHub issues and might close the issue, if it is not an actual bug. -->
+
+**Bug report**
+<!-- A clear and concise description of the bug you encountered  -->
+
+**To reproduce**
+<!-- Steps to reproduce the behavior or verify the issue -->
+
+**System info**
+<!-- Please add relevant information about your system, e.g. Win/Linux, OS version, (WSL?), etc. Please also include the output of `sdk version` -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,7 +6,7 @@ labels: 'bug'
 assignees: ''
 
 ---
-<!-- Thank you for using the SDKMAN! issue tracker! If you are unsure if it is a bug, then consider using the Slack chat before creating a new issue. Please understand, that we cannot offer regular support through GitHub issues and might close the issue, if it is not an actual bug. -->
+<!-- Thank you for using the SDKMAN! issue tracker! If you are unsure if it is a bug, then consider using the Slack chat before creating a new issue. Please understand, that we cannot offer regular support through GitHub issues and might close the issue, if it is not an actual bug! -->
 
 **Bug report**
 <!-- A clear and concise description of the bug you encountered  -->
@@ -15,4 +15,8 @@ assignees: ''
 <!-- Steps to reproduce the behavior or verify the issue -->
 
 **System info**
-<!-- Please add relevant information about your system, e.g. Win/Linux, OS version, (WSL?), etc. Please also include the output of `sdk version` -->
+<!-- Please add relevant information about your system:
+- OS (e.g. Windows, Linux, Mac, Cygwin, WSL, etc.) and version
+- Shell and version (e.g. `bash --version`/`zsh --version`)
+- The output of `sdk version`
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: SDKMAN! usage documentation
+    url: https://sdkman.io/usage
+    about: Find documentation about the available commands here.
+  - name: SDKMAN! Slack community
+    url: https://slack.sdkman.io/
+    about: Please ask and answer questions about usage of SDKMAN! here.
+  - name: SDKMAN! on Stack Overflow
+    url: https://stackoverflow.com/questions/tagged/sdkman
+    about: You might find help to common issues here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,15 @@
+---
+name: Feature request
+about: Suggest an idea for SDKMAN!
+title: 'Feature: [A concise title]'
+labels: 'enhancement'
+assignees: ''
+---
+
+<!-- Thank you for suggesting a new feature. Please consider discussing your idea in our Slack channel before requesting a new feature. -->
+
+- [ ] I have read the [CONTRIBUTING guidelines](CONTRIBUTING.md)
+
+**Feature request**
+<!-- A clear and precise description of what new or changed feature you want. Please include the reason, why you would need the feature. E.g. what problem does it solve? Or which workflow is currently frustrating and will be improved by this? -->
+

--- a/.github/ISSUE_TEMPLATE/support_request.md
+++ b/.github/ISSUE_TEMPLATE/support_request.md
@@ -18,4 +18,8 @@ Please consider the following things. Note, that ignoring all of these might lea
 <!-- A clear and concise description of the issue you are encountering -->
 
 **System info**
-<!-- Please add relevant information about your system, e.g. Win/Linux, OS version, (WSL?), etc. Please also include the output of `sdk version` -->
+<!-- Please add relevant information about your system:
+- OS (e.g. Windows, Linux, Mac, Cygwin, WSL, etc.) and version
+- Shell and version (e.g. `bash --version`/`zsh --version`)
+- The output of `sdk version`
+-->

--- a/.github/ISSUE_TEMPLATE/support_request.md
+++ b/.github/ISSUE_TEMPLATE/support_request.md
@@ -1,0 +1,21 @@
+---
+name: Support request or question
+about: You need help using SDKMAN!
+title: "Question: [Short summary]"
+labels: 'support'
+assignees: ''
+
+---
+<!-- Thank you for using SDKMAN!. We want to help users using the software, but we also try to avoid filling the issue tracker with too many support requests. We kindly ask you to use our Slack channel #user-issues before posting.
+
+Please consider the following things. Note, that ignoring all of these might lead to the issue simply being closed. -->
+
+- [ ] I have checked [the documentation](https://sdkman.io/usage)
+- [ ] I have done a quick search in [past issues](https://github.com/rclone/rclone/issues?q=) or [Stack Overflow](https://stackoverflow.com/questions/tagged/sdkman) for similar problems
+- [ ] I have brought up a conversation in the [Slack User Issues Channel](https://sdkman.slack.com/app_redirect?channel=user-issues)
+
+**Question**
+<!-- A clear and concise description of the issue you are encountering -->
+
+**System info**
+<!-- Please add relevant information about your system, e.g. Win/Linux, OS version, (WSL?), etc. Please also include the output of `sdk version` -->

--- a/.github/pull_request_tempalte.md
+++ b/.github/pull_request_tempalte.md
@@ -1,0 +1,6 @@
+<!-- To raise a new Pull Request, the following prerequisites need to be met. Please tick before proceeding: -->
+
+- [ ] a GitHub Issue was opened for this feature / bug.
+- [ ] test coverage was added (Cucumber or Spock as appropriate).
+
+Fixes #XXX

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ We keep a distinction between Bugs/Issues, New Features and Support Requests. We
 
 The [GitHub Issue Tracker](https://github.com/sdkman/sdkman-cli/issues/new) provides templates for required informations.
 
-**Unfortunately we might simply close any Github Issues that has not followed the requested template.**
+**Unfortunately we might simply close any Github Issues that have not followed the requested template.**
 
 ### Pull Requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,20 +1,18 @@
 ## Contributing
 
-We greatly value the feedback and contributions of our users. We have a simple process in place to facilitate this:
+We greatly value the feedback and contributions of our users.
 
-### Bugs and New Features
-
-We keep a distinction between New Features and Bugs/Issues. We try to minimise the noise in our Github Issues stream by first having a conversation on [SDKMAN Slack](https://slack.sdkman.io). Simply sign up and join one of the following channels:
+We keep a distinction between Bugs/Issues, New Features and Support Requests. We also try to minimise the noise in our GitHub Issues stream and prefer having a conversation on [SDKMAN Slack](https://slack.sdkman.io) before creating new issues, if you are not fully sure how to categorize your request. Simply sign up and join one of the following channels:
 
 - User Issues can be raised in our [User Issues channel](https://sdkman.slack.com/app_redirect?channel=user-issues).
 - New Features or Enhancements can be discussed in our [CLI Development channel](https://sdkman.slack.com/app_redirect?channel=cli-development).
 
-After accepting a new feature or confirming that a bug was found, an Issue may be raised filling in the provided Issue Template on the [GitHub Issue Tracker](https://github.com/sdkman/sdkman-cli/issues/new).
+The [GitHub Issue Tracker](https://github.com/sdkman/sdkman-cli/issues/new) provides templates for required informations.
 
-**Unfortunately we will close any Github Issues that have not followed this process of prior discussion.**
+**Unfortunately we might simply close any Github Issues that has not followed the requested template.**
 
 ### Pull Requests
 
-Pull Requests are _always_ very welcome, but require the initial discussion on Slack followed by a Github Issue as described above. The PR template is to be filled in before submission, ensuring that it is _linked back_ to the Github Issue number by replacing `#XXX` with the appropriate Issue reference.
+Pull Requests are _always_ very welcome, but require a valid GitHub Issue as decribed above. The PR template is to be filled in before submission, ensuring that it is _linked back_ to the Github Issue number by replacing `#XXX` with the appropriate issue reference.
 
-Each PR should also be accompanied by a passing test(s) proving it's validity (where feasible). The feasibility of the test will emerge in the initial discussions on Slack and in the Github Issue.
+Each PR should also be accompanied by a passing test(s) proving it's validity (where feasible). The feasibility of the test will emerge in the initial discussions of the issue.

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,7 +1,0 @@
-We require a conversation to take place in the appropriate [SDKMAN Slack](https://slack.sdkman.io) channel before raising a new Github Issue. Please note that **issues will be closed immediately if prior discussion did not take place**. We need to do this to help manage the quality and validity of Issues raised on this project.
-
-Please tick one:
-- [ ] this is a new Feature Request, a conversation was started in the [Slack CLI Development Channel](https://sdkman.slack.com/app_redirect?channel=cli-development).
-- [ ] this is a new Bug Report or Issue, a conversation was started in [Slack User Issues Channel](https://sdkman.slack.com/app_redirect?channel=user-issues).
-
-Please explain the Issue / Feature Request here:

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,0 @@
-To raise a new Pull Request, the following prerequisites need to be met. Please tick before proceeding:
-
-- [ ] a conversation was held in the appropriate [SDKMAN Slack](https://slack.sdkman.io) channel.
-- [ ] a Github Issue was opened for this feature / bug.
-- [ ] test coverage was added (Cucumber or Spock as appropriate).
-
-This addresses Issue #XXX


### PR DESCRIPTION
Issues are either a bug report, feature request or support request. Labels
are automaticaly added to the issues respectively: bug, enhancement, support.

The templates suggest using the Slack before opening an issue, but no longer
say it is a hard requirement. This might give a more inclusive impression to
people reporting who are not Slack users.

- [x] a conversation was held in the appropriate [SDKMAN Slack](https://slack.sdkman.io) channel.
- [x] a Github Issue was opened for this feature / bug.
- [ ] test coverage was added (Cucumber or Spock as appropriate).

This addresses Issue #753

CONTRIBUTING.md was also rephrased.

The tag 'support' would be new. We could not set a tag there. Or even rephrase the text to be more 'We do not want to offer support via GitHub AT ALL', if requested.

I have set it to the default branch of my fork, so you can test how it looks via this repository: https://github.com/draget-forks/sdkman-cli (feel free to create test-issues or PRs in there!)