### PR TITLE
Remove legacy bash workaround from __sdk_update

### DIFF
--- a/src/main/bash/sdkman-update.sh
+++ b/src/main/bash/sdkman-update.sh
@@ -26,13 +26,6 @@ function __sdk_update() {
 	__sdkman_echo_debug "Fetched candidates: $fresh_candidates_csv"
 
 	if [[ -n "${fresh_candidates_csv}" ]] && ! grep -iq 'html' <<< "${fresh_candidates_csv}"; then
-		# legacy bash workaround
-		if [[ "$bash_shell" == 'true' && "$BASH_VERSINFO" -lt 4 ]]; then
-			__sdkman_legacy_bash_message
-			echo "$fresh_candidates_csv" >| "$SDKMAN_CANDIDATES_CACHE"
-			return 0
-		fi
-
 		__sdkman_echo_debug "Fresh and cached candidate lengths: ${#fresh_candidates_csv} ${#SDKMAN_CANDIDATES_CSV}"
 
 		local fresh_candidates combined_candidates diff_candidates

--- a/src/main/bash/sdkman-utils.sh
+++ b/src/main/bash/sdkman-utils.sh
@@ -110,13 +110,3 @@ function __sdkman_echo_confirm() {
 		echo -e -n "\033[1;33m$1\033[0m"
 	fi
 }
-
-function __sdkman_legacy_bash_message() {
-	__sdkman_echo_red "An outdated version of bash was detected on your system!"
-	echo ""
-	__sdkman_echo_red "We recommend upgrading to bash 4.x, you have:"
-	echo ""
-	__sdkman_echo_yellow "  $BASH_VERSION"
-	echo ""
-	__sdkman_echo_yellow "Need to use brute force to replace candidates..."
-}


### PR DESCRIPTION
Remove legacy bash workaround from `__sdk_update`.

The code that didn't work on legacy bash was removed a long time ago, so the workaround is no longer necessary.

The workaround prevents 4 or so tests from completing successfully on legacy bash, so it's very useful to remove the workaround, so we can run the test suite on bash 3.2.x.