### PR TITLE
Rename duplicate path initialisation scenario name

### DIFF
--- a/src/test/cucumber/path_initialisation.feature
+++ b/src/test/cucumber/path_initialisation.feature
@@ -17,7 +17,7 @@ Feature: Path Initialisation
 		And I enter "echo $PATH"
 		Then I see a single occurrence of "grails"
 
-	Scenario: Install a candidate and see it on the PATH
+	Scenario: sdkman is initialised without candidates
 		Given the system is bootstrapped
 		When I enter "echo $PATH"
 		Then I see no occurrences of "grails"


### PR DESCRIPTION
Rename duplicate path initialisation scenario name.

Two scenarios both had the same name. Renamed the incorrectly named one.