### PR TITLE
Add support for Linux ARM64

### DIFF
--- a/src/main/bash/sdkman-init.sh
+++ b/src/main/bash/sdkman-init.sh
@@ -34,6 +34,8 @@ SDKMAN_PLATFORM="$(uname)"
 if [[ "$SDKMAN_PLATFORM" == 'Linux' ]]; then
 	if [[ "$(uname -m)" == 'i686' ]]; then
 		SDKMAN_PLATFORM+='32'
+	elif [[ "$(uname -m)" == 'aarch64' ]]; then
+		SDKMAN_PLATFORM+='ARM64'
 	else
 		SDKMAN_PLATFORM+='64'
 	fi

--- a/src/test/groovy/sdkman/steps/initialisation_steps.groovy
+++ b/src/test/groovy/sdkman/steps/initialisation_steps.groovy
@@ -81,7 +81,7 @@ And(~'^offline mode is enabled with unreachable internet$') { ->
 And(~'^a machine with "(.*)" installed$') { String platform ->
 	def binFolder = "$sdkmanBaseDir/bin" as File
 	UnameStub.prepareIn(binFolder)
-			.forPlatform(asSdkmanPlatform(platform))
+			.forPlatform(asSdkmanPlatform(platform, null))
 			.build()
 }
 

--- a/src/test/groovy/sdkman/steps/stub_steps.groovy
+++ b/src/test/groovy/sdkman/steps/stub_steps.groovy
@@ -28,13 +28,13 @@ And(~'^the candidate "([^"]*)" version "([^"]*)" is available for download$') { 
 }
 
 And(~/^the appropriate universal hooks are available for "([^"]*)" version "([^"]*)" on "([^"]*)"$/) { String candidate, String version, String platform ->
-	String lcPlatform = UnixUtils.asSdkmanPlatform(platform).toLowerCase()
+	String lcPlatform = UnixUtils.asSdkmanPlatform(platform, null).toLowerCase()
 	primeUniversalHookFor("pre", candidate, version, lcPlatform)
 	primeUniversalHookFor("post", candidate, version, lcPlatform)
 }
 
 And(~/^the appropriate multi-platform hooks are available for "([^"]*)" version "([^"]*)" on "([^"]*)"$/) { String candidate, String version, String platform ->
-	String lcPlatform = UnixUtils.asSdkmanPlatform(platform).toLowerCase()
+	String lcPlatform = UnixUtils.asSdkmanPlatform(platform, null).toLowerCase()
 	primePlatformSpecificHookFor("pre", candidate, version, lcPlatform)
 	primePlatformSpecificHookFor("post", candidate, version, lcPlatform)
 }
@@ -44,23 +44,23 @@ And(~'^the candidate "([^"]*)" version "([^"]*)" is not available for download$'
 }
 
 And(~/^the candidate "(.*)" version "(.*)" is available for download on "(.*)"$/) { String candidate, String version, String platform ->
-	String lcPlatform = UnixUtils.asSdkmanPlatform(platform).toLowerCase()
+	String lcPlatform = UnixUtils.asSdkmanPlatform(platform, null).toLowerCase()
 	primeEndpointWithString("/candidates/validate/${candidate}/${version}/${lcPlatform}", "valid")
 	primeDownloadFor(SERVICE_UP_URL, candidate, version, lcPlatform)
 }
 
 And(~/^a "([^"]*)" install hook is served for "([^"]*)" "([^"]*)" on "([^"]*)" that returns successfully$/) { String phase, String candidate, String version, String platform ->
-	String lcPlatform = UnixUtils.asSdkmanPlatform(platform).toLowerCase()
+	String lcPlatform = UnixUtils.asSdkmanPlatform(platform, null).toLowerCase()
 	primeEndpointWithString("/hooks/${phase}/${candidate}/${version}/${lcPlatform}", phase == "pre" ? preInstallationHookSuccess() : postInstallationHookSuccess())
 }
 
 And(~/^a "([^"]*)" install hook is served for "([^"]*)" "([^"]*)" on "([^"]*)" that returns a failure$/) { String phase, String candidate, String version, String platform ->
-	String lcPlatform = UnixUtils.asSdkmanPlatform(platform).toLowerCase()
+	String lcPlatform = UnixUtils.asSdkmanPlatform(platform, null).toLowerCase()
 	primeEndpointWithString("/hooks/${phase}/${candidate}/${version}/${lcPlatform}", phase == "pre" ? preInstallationHookFailure() : postInstallationHookFailure())
 }
 
 And(~/^the candidate "(.*?)" version "(.*?)" is not available for download on "(.*?)"$/) { String candidate, String version, String platform ->
-	String lcPlatform = UnixUtils.asSdkmanPlatform(platform).toLowerCase()
+	String lcPlatform = UnixUtils.asSdkmanPlatform(platform, null).toLowerCase()
 	primeEndpointWithString("/candidates/validate/${candidate}/${version}/${lcPlatform}", "invalid")
 }
 

--- a/src/test/groovy/sdkman/support/UnixUtils.groovy
+++ b/src/test/groovy/sdkman/support/UnixUtils.groovy
@@ -3,7 +3,14 @@ package sdkman.support
 class UnixUtils {
 
 	static getPlatform() {
-		asSdkmanPlatform(System.getProperty("os.name"))
+		def os = System.getProperty("os.name")
+		def arch = System.getProperty("os.arch")
+
+		if("aarch64".equals(arch)) {
+			asSdkmanPlatform("LinuxARM64")
+		} else {
+			asSdkmanPlatform(os)
+		}
 	}
 
 	static asSdkmanPlatform(platform) {

--- a/src/test/groovy/sdkman/support/UnixUtils.groovy
+++ b/src/test/groovy/sdkman/support/UnixUtils.groovy
@@ -7,7 +7,7 @@ class UnixUtils {
 	}
 
 	static asSdkmanPlatform(platform, architecture = null) {
-		if("aarch64".equals(architecture)) {
+		if("aarch64" == architecture) {
 			platform += architecture
 		}
 
@@ -27,7 +27,7 @@ class UnixUtils {
 				break
 			case "Linuxaarch64":
 				result = "LinuxARM64"
-				break;
+				break
 			case "FreeBSD":
 				result = "FreeBSD"
 				break

--- a/src/test/groovy/sdkman/support/UnixUtils.groovy
+++ b/src/test/groovy/sdkman/support/UnixUtils.groovy
@@ -3,17 +3,14 @@ package sdkman.support
 class UnixUtils {
 
 	static getPlatform() {
-		def os = System.getProperty("os.name")
-		def arch = System.getProperty("os.arch")
-
-		if("aarch64".equals(arch)) {
-			asSdkmanPlatform("LinuxARM64")
-		} else {
-			asSdkmanPlatform(os)
-		}
+		asSdkmanPlatform(System.getProperty("os.name"), System.getProperty("os.arch"))
 	}
 
-	static asSdkmanPlatform(platform) {
+	static asSdkmanPlatform(platform, architecture = null) {
+		if("aarch64".equals(architecture)) {
+			platform += architecture
+		}
+
 		def result
 		switch (platform) {
 			case "Mac OS X":
@@ -28,6 +25,9 @@ class UnixUtils {
 			case "Linux 32":
 				result = "Linux32"
 				break
+			case "Linuxaarch64":
+				result = "LinuxARM64"
+				break;
 			case "FreeBSD":
 				result = "FreeBSD"
 				break

--- a/src/test/groovy/sdkman/support/UnixUtils.groovy
+++ b/src/test/groovy/sdkman/support/UnixUtils.groovy
@@ -6,7 +6,7 @@ class UnixUtils {
 		asSdkmanPlatform(System.getProperty("os.name"), System.getProperty("os.arch"))
 	}
 
-	static asSdkmanPlatform(platform, architecture = null) {
+	static asSdkmanPlatform(platform, architecture) {
 		if("aarch64" == architecture) {
 			platform += architecture
 		}


### PR DESCRIPTION
Connected to issue: #640

This adds support for platform detection of Linux ARM64 (AArch64).

I had to change code in the following places to make this works:
- [x] sdkman/sdkman-db-migrations#276
- [x] sdkman/sdkman-hooks#18
- [x] sdkman/sdkman-candidates#13
- [x] sdkman/sdkman-broker#2
- [x] sdkman/vendor-release#1


Hopefully I got all the places covered ;-)