### PR TITLE
Add support to Git Bash (switch default)

### DIFF
--- a/src/main/bash/sdkman-path-helpers.sh
+++ b/src/main/bash/sdkman-path-helpers.sh
@@ -82,7 +82,7 @@ function __sdkman_link_candidate_version() {
 
 	# Change the 'current' symlink for the candidate, hence affecting all shells.
 	if [[ -L "${SDKMAN_CANDIDATES_DIR}/${candidate}/current" || -d "${SDKMAN_CANDIDATES_DIR}/${candidate}/current" ]]; then
-		rm -f "${SDKMAN_CANDIDATES_DIR}/${candidate}/current"
+		rm -rf "${SDKMAN_CANDIDATES_DIR}/${candidate}/current"
 	fi
 
 	ln -s "${version}" "${SDKMAN_CANDIDATES_DIR}/${candidate}/current"


### PR DESCRIPTION
When working with git bash it ends up with an error saying it cannot remove the directory 'current' adding the -R will solve it for both nix and win.