### PR TITLE
#827: Add a helpful tip when incorrect version is provided while installation

### DIFF
--- a/src/main/bash/sdkman-env-helpers.sh
+++ b/src/main/bash/sdkman-env-helpers.sh
@@ -88,6 +88,10 @@ function __sdkman_determine_version() {
 			__sdkman_echo_red " * $version is an invalid version"
 			__sdkman_echo_red " * $candidate binaries are incompatible with $SDKMAN_PLATFORM"
 			__sdkman_echo_red " * $candidate has not been released yet"
+			
+			__sdkman_echo_green "Tip: Try finding a valid version by running the command:"
+			__sdkman_echo_green "sdk list $candidate"
+			__sdkman_echo_green "and rerun with the correct version"
 			return 1
 		fi
 	fi

--- a/src/main/bash/sdkman-env-helpers.sh
+++ b/src/main/bash/sdkman-env-helpers.sh
@@ -89,9 +89,8 @@ function __sdkman_determine_version() {
 			__sdkman_echo_red " * $candidate binaries are incompatible with $SDKMAN_PLATFORM"
 			__sdkman_echo_red " * $candidate has not been released yet"
 			
-			__sdkman_echo_green "Tip: Try finding a valid version by running the command:"
-			__sdkman_echo_green "sdk list $candidate"
-			__sdkman_echo_green "and rerun with the correct version"
+			__sdkman_echo_yellow "Tip: see all available versions for your platform:"
+			__sdkman_echo_yellow "$ sdk list $candidate"
 			return 1
 		fi
 	fi

--- a/src/test/resources/features/java_installation.feature
+++ b/src/test/resources/features/java_installation.feature
@@ -49,9 +49,8 @@ Feature: Java Multi Platform Binary Distribution
 		And I see " * 8.0.111 is an invalid version"
 		And I see " * java binaries are incompatible with FreeBSD"
 		And I see " * java has not been released yet"
-		And I see "Tip: Try finding a valid version by running the command:"
-		And I see "sdk list java"
-		And I see "and rerun with the correct version"
+		And I see "Tip: see all available versions for your platform:"
+		And I see "$ sdk list java"
 		And the candidate "java" version "8.0.111" is not installed
 
 	Scenario: Platform is not supported for default version and user is notified
@@ -64,7 +63,6 @@ Feature: Java Multi Platform Binary Distribution
 		And I see " * 8.0.111 is an invalid version"
 		And I see " * java binaries are incompatible with FreeBSD"
 		And I see " * java has not been released yet"
-		And I see "Tip: Try finding a valid version by running the command:"
-		And I see "sdk list java"
-		And I see "and rerun with the correct version"
+		And I see "Tip: see all available versions for your platform:"
+		And I see "$ sdk list java"
 		And the candidate "java" version "8.0.111" is not installed

--- a/src/test/resources/features/java_installation.feature
+++ b/src/test/resources/features/java_installation.feature
@@ -49,6 +49,9 @@ Feature: Java Multi Platform Binary Distribution
 		And I see " * 8.0.111 is an invalid version"
 		And I see " * java binaries are incompatible with FreeBSD"
 		And I see " * java has not been released yet"
+		And I see "Tip: Try finding a valid version by running the command:"
+		And I see "sdk list java"
+		And I see "and rerun with the correct version"
 		And the candidate "java" version "8.0.111" is not installed
 
 	Scenario: Platform is not supported for default version and user is notified
@@ -61,4 +64,7 @@ Feature: Java Multi Platform Binary Distribution
 		And I see " * 8.0.111 is an invalid version"
 		And I see " * java binaries are incompatible with FreeBSD"
 		And I see " * java has not been released yet"
+		And I see "Tip: Try finding a valid version by running the command:"
+		And I see "sdk list java"
+		And I see "and rerun with the correct version"
 		And the candidate "java" version "8.0.111" is not installed


### PR DESCRIPTION
The console will now display additional text describing a helpful command if installation fails due to incorrect verison provided.