### PR TITLE
Add support for macOS arm64

### DIFF
--- a/src/main/bash/sdkman-init.sh
+++ b/src/main/bash/sdkman-init.sh
@@ -39,6 +39,10 @@ if [[ "$SDKMAN_PLATFORM" == 'Linux' ]]; then
 	else
 		SDKMAN_PLATFORM+='64'
 	fi
+elif [[ "$SDKMAN_PLATFORM" == 'Darwin' ]]; then
+	if [[ "$(uname -m)" == 'arm64' ]]; then
+		SDKMAN_PLATFORM+='ARM64'
+	fi
 fi
 export SDKMAN_PLATFORM
 

--- a/src/test/groovy/sdkman/support/UnixUtils.groovy
+++ b/src/test/groovy/sdkman/support/UnixUtils.groovy
@@ -15,6 +15,9 @@ class UnixUtils {
 			case "Mac OS X":
 				result = "Darwin"
 				break
+			case "Mac OS X aarch64":
+				result = "DarwinARM64"
+				break
 			case "Linux":
 				result = "Linux64"
 				break


### PR DESCRIPTION
Address #830 by adding "DarwinARM64". No Java candidates will be returned since they are not yet added.