### PR TITLE
source only files ending with .sh

### DIFF
--- a/src/main/bash/sdkman-init.sh
+++ b/src/main/bash/sdkman-init.sh
@@ -79,7 +79,7 @@ fi
 # <https://github.com/sdkman/sdkman-extensions>.
 OLD_IFS="$IFS"
 IFS=$'\n'
-scripts=($(find "${SDKMAN_DIR}/src" "${SDKMAN_DIR}/ext" -type f -name 'sdkman-*'))
+scripts=($(find "${SDKMAN_DIR}/src" "${SDKMAN_DIR}/ext" -type f -name 'sdkman-*.sh'))
 for f in "${scripts[@]}"; do
 	source "$f"
 done


### PR DESCRIPTION
I use zsh and also make use of a [zmodule](https://github.com/zdharma/zinit#zinit-module) that compiles sourced files for faster execution. This compilation produces binary blobs which end in `.zwc`.

The change proposed here is to make sure sdkman only sources the `.sh` files and nothing else, otherwise it will keep producing errors at startup.

My current work-around is to redirect stderr, but I think adding the `.sh` suffix makes more sense.