### PR TITLE
Add `sdk env install` to usage instructions

### DIFF
--- a/src/main/bash/sdkman-help.sh
+++ b/src/main/bash/sdkman-help.sh
@@ -28,7 +28,7 @@ function __sdk_help() {
 	__sdkman_echo_no_colour "       use       or u    <candidate> <version>"
 	__sdkman_echo_no_colour "       default   or d    <candidate> [version]"
 	__sdkman_echo_no_colour "       home      or h    <candidate> <version>"
-	__sdkman_echo_no_colour "       env       or e    [init|clear]"
+	__sdkman_echo_no_colour "       env       or e    [init|install|clear]"
 	__sdkman_echo_no_colour "       current   or c    [candidate]"
 	__sdkman_echo_no_colour "       upgrade   or ug   [candidate]"
 	__sdkman_echo_no_colour "       version   or v"


### PR DESCRIPTION
Adds the new `sdk env install` command to the usage instructions.