### PR TITLE
Fix rm asking to remove file on some zsh

### DIFF
--- a/bin/download.sh
+++ b/bin/download.sh
@@ -50,6 +50,6 @@ fi
 echo "Extracting archive to: $DESTINATION_DIR"
 unzip -oq "$ARCHIVE" -d "$TMP_DIR"
 mkdir "$DESTINATION_DIR"
-mv "$TMP_DIR"/**/* "$DESTINATION_DIR"
+mv -f "$TMP_DIR"/**/* "$DESTINATION_DIR"
 
 rm -rf "$TMP_DIR"

--- a/src/main/bash/sdkman-flush.sh
+++ b/src/main/bash/sdkman-flush.sh
@@ -25,7 +25,7 @@ function __sdk_flush() {
 		;;
 	version)
 		if [[ -f "${SDKMAN_DIR}/var/version" ]]; then
-			rm "${SDKMAN_DIR}/var/version"
+			rm -f "${SDKMAN_DIR}/var/version"
 			__sdkman_echo_green "Version file has been flushed."
 		fi
 		;;
@@ -63,8 +63,8 @@ function __sdkman_cleanup_folder() {
 
 function __sdkman_cleanup_broadcast() {
 	if [[ -f "${SDKMAN_DIR}/var/broadcast_id" ]]; then
-		rm "${SDKMAN_DIR}/var/broadcast_id"
-		rm "${SDKMAN_DIR}/var/broadcast"
+		rm -f "${SDKMAN_DIR}/var/broadcast_id"
+		rm -f "${SDKMAN_DIR}/var/broadcast"
 		__sdkman_echo_green "Broadcast has been flushed."
 	else
 		__sdkman_echo_no_colour "No prior broadcast found so not flushed."

--- a/src/main/bash/sdkman-install.sh
+++ b/src/main/bash/sdkman-install.sh
@@ -71,7 +71,7 @@ function __sdkman_install_candidate_version() {
 
 	rm -rf "${SDKMAN_DIR}/tmp/out"
 	unzip -oq "${SDKMAN_DIR}/archives/${candidate}-${version}.zip" -d "${SDKMAN_DIR}/tmp/out"
-	mv "$SDKMAN_DIR"/tmp/out/* "${SDKMAN_CANDIDATES_DIR}/${candidate}/${version}"
+	mv -f "$SDKMAN_DIR"/tmp/out/* "${SDKMAN_CANDIDATES_DIR}/${candidate}/${version}"
 	__sdkman_echo_green "Done installing!"
 	echo ""
 }
@@ -159,7 +159,7 @@ function __sdkman_download() {
 		__sdkman_echo_debug "Processed binary as: $zip_output"
 		__sdkman_echo_debug "Completed post-installation hook..."
 
-		mv "$zip_output" "$zip_archive_target"
+		mv -f "$zip_output" "$zip_archive_target"
 		__sdkman_echo_debug "Moved to archive folder: $zip_archive_target"
 	else
 		echo ""

--- a/src/main/bash/sdkman-install.sh
+++ b/src/main/bash/sdkman-install.sh
@@ -175,7 +175,7 @@ function __sdkman_validate_zip() {
 	zip_archive="$1"
 	zip_ok=$(unzip -t "$zip_archive" | grep 'No errors detected in compressed data')
 	if [ -z "$zip_ok" ]; then
-		rm "$zip_archive"
+		rm -f "$zip_archive"
 		echo ""
 		__sdkman_echo_red "Stop! The archive was corrupt and has been removed! Please try installing again."
 		return 1

--- a/src/test/groovy/sdkman/stubs/HookResponses.groovy
+++ b/src/test/groovy/sdkman/stubs/HookResponses.groovy
@@ -26,7 +26,7 @@ function __sdkman_pre_installation_hook {
 		'''\
 #!/usr/bin/env bash
 function __sdkman_post_installation_hook {
-	mv $binary_input $zip_output
+	mv -f $binary_input $zip_output
 	echo "Post-installation hook success"
 	return 0
 }

--- a/src/test/resources/__files/hooks/post_hook_java_8.0.111_universal.sh
+++ b/src/test/resources/__files/hooks/post_hook_java_8.0.111_universal.sh
@@ -2,5 +2,5 @@
 # passthrough used for zip binaries
 function __sdkman_post_installation_hook() {
 	echo "POST: passthrough $binary_input to $zip_output"
-	mv "$binary_input" "$zip_output"
+	mv -f "$binary_input" "$zip_output"
 }


### PR DESCRIPTION
I'm trying to fix the following:

```sh-session
❯ sdk install java
==== BROADCAST =================================================================
* 2021-01-07: mvnd 0.3.0 available on SDKMAN! https://git.io/JLxCq
* 2021-01-06: micronaut 2.2.3 available on SDKMAN!
* 2021-01-04: gradle 6.8-rc-5 available on SDKMAN!
================================================================================

Downloading: java 11.0.9.hs-adpt

In progress...

################################################################################################################################ 100.0%################################################################################################################################ 100.0%

Repackaging Java 11.0.9.hs-adpt...

Done repackaging...
rm: remove regular file '/home/vscode/.sdkman/tmp/java-11.0.9.hs-adpt.bin'? y

Installing: java 11.0.9.hs-adpt
Done installing!


Setting java 11.0.9.hs-adpt as default.
```

But I think this might actually be part of the package hook script rather than the sdk cli. Anyway, I believe adding `-f` to the `rm` is always good to prevent such thing.