### PR TITLE
Improved error message when candidate version not found

### DIFF
--- a/src/main/bash/sdkman-default.sh
+++ b/src/main/bash/sdkman-default.sh
@@ -27,9 +27,14 @@ function __sdk_default() {
 
 	if [ ! -d "${SDKMAN_CANDIDATES_DIR}/${candidate}/${VERSION}" ]; then
 		echo ""
-		__sdkman_echo_red "Stop! Candidate version is not installed. Please run:"
+		__sdkman_echo_red "Stop! ${candidate} ${VERSION} is not available. Possible causes:"
+		__sdkman_echo_red " * ${VERSION} is an invalid version"
+		__sdkman_echo_red " * ${candidate} binaries are incompatible with ${SDKMAN_PLATFORM}"
+		__sdkman_echo_red " * ${candidate} has not been released yet"
 		echo ""
-		__sdkman_echo_red "$ sdk install ${candidate} ${VERSION}"
+		__sdkman_echo_yellow "Tip: see all available versions for your platform:"
+		echo ""
+		__sdkman_echo_yellow "  $ sdk list ${candidate}"
 		return 1
 	fi
 

--- a/src/main/bash/sdkman-default.sh
+++ b/src/main/bash/sdkman-default.sh
@@ -27,7 +27,9 @@ function __sdk_default() {
 
 	if [ ! -d "${SDKMAN_CANDIDATES_DIR}/${candidate}/${VERSION}" ]; then
 		echo ""
-		__sdkman_echo_red "Stop! ${candidate} ${VERSION} is not installed."
+		__sdkman_echo_red "Stop! Candidate version is not installed. Please run:"
+		echo ""
+		__sdkman_echo_red "$ sdk install ${candidate} ${VERSION}"
 		return 1
 	fi
 

--- a/src/main/bash/sdkman-home.sh
+++ b/src/main/bash/sdkman-home.sh
@@ -27,9 +27,14 @@ function __sdk_home() {
 
 	if [[ ! -d "${SDKMAN_CANDIDATES_DIR}/${candidate}/${version}" ]]; then
 		echo ""
-		__sdkman_echo_red "Stop! Candidate version is not installed. Please run:"
+		__sdkman_echo_red "Stop! ${candidate} ${version} is not available. Possible causes:"
+		__sdkman_echo_red " * ${version} is an invalid version"
+		__sdkman_echo_red " * ${candidate} binaries are incompatible with ${SDKMAN_PLATFORM}"
+		__sdkman_echo_red " * ${candidate} has not been released yet"
 		echo ""
-		__sdkman_echo_red "$ sdk install ${candidate} ${version}"
+		__sdkman_echo_yellow "Tip: see all available versions for your platform:"
+		echo ""
+		__sdkman_echo_yellow "  $ sdk list ${candidate}"
 		return 1
 	fi
 

--- a/src/main/bash/sdkman-home.sh
+++ b/src/main/bash/sdkman-home.sh
@@ -27,7 +27,9 @@ function __sdk_home() {
 
 	if [[ ! -d "${SDKMAN_CANDIDATES_DIR}/${candidate}/${version}" ]]; then
 		echo ""
-		__sdkman_echo_red "Stop! ${candidate} ${version} is not installed."
+		__sdkman_echo_red "Stop! Candidate version is not installed. Please run:"
+		echo ""
+		__sdkman_echo_red "$ sdk install ${candidate} ${version}"
 		return 1
 	fi
 

--- a/src/main/bash/sdkman-use.sh
+++ b/src/main/bash/sdkman-use.sh
@@ -26,7 +26,9 @@ function __sdk_use() {
 
 	if [[ ! -d "${SDKMAN_CANDIDATES_DIR}/${candidate}/${version}" ]]; then
 		echo ""
-		__sdkman_echo_red "Stop! ${candidate} ${version} is not installed."
+		__sdkman_echo_red "Stop! Candidate version is not installed. Please run:"
+		echo ""
+		__sdkman_echo_red "$ sdk install ${candidate} ${version}"
 		return 1
 	fi
 

--- a/src/main/bash/sdkman-use.sh
+++ b/src/main/bash/sdkman-use.sh
@@ -26,9 +26,14 @@ function __sdk_use() {
 
 	if [[ ! -d "${SDKMAN_CANDIDATES_DIR}/${candidate}/${version}" ]]; then
 		echo ""
-		__sdkman_echo_red "Stop! Candidate version is not installed. Please run:"
+		__sdkman_echo_red "Stop! ${candidate} ${version} is not available. Possible causes:"
+		__sdkman_echo_red " * ${version} is an invalid version"
+		__sdkman_echo_red " * ${candidate} binaries are incompatible with ${SDKMAN_PLATFORM}"
+		__sdkman_echo_red " * ${candidate} has not been released yet"
 		echo ""
-		__sdkman_echo_red "$ sdk install ${candidate} ${version}"
+		__sdkman_echo_yellow "Tip: see all available versions for your platform:"
+		echo ""
+		__sdkman_echo_yellow "  $ sdk list ${candidate}"
 		return 1
 	fi
 

--- a/src/test/resources/features/default_version.feature
+++ b/src/test/resources/features/default_version.feature
@@ -8,9 +8,12 @@ Feature: Default Version
 		Given the candidate "groovy" version "2.0.5" is a valid candidate version
 		And the system is bootstrapped
 		When I enter "sdk default groovy 2.0.5"
-		Then I see "Stop! Candidate version is not installed. Please run:"
-		And I see ""
-		And I see "$ sdk install groovy 2.0.5"
+		Then I see "Stop! groovy 2.0.5 is not available. Possible causes:"
+		And I see "* 2.0.5 is an invalid version"
+		And I see "* groovy binaries are incompatible with LinuxX64"
+		And I see "* groovy has not been released yet"
+		And I see "Tip: see all available versions for your platform:"
+		And I see "$ sdk list groovy"
 
 	Scenario: Default a candidate version that is installed and not default
 		Given the candidate "groovy" version "2.0.5" is a valid candidate version

--- a/src/test/resources/features/default_version.feature
+++ b/src/test/resources/features/default_version.feature
@@ -8,7 +8,9 @@ Feature: Default Version
 		Given the candidate "groovy" version "2.0.5" is a valid candidate version
 		And the system is bootstrapped
 		When I enter "sdk default groovy 2.0.5"
-		Then I see "Stop! groovy 2.0.5 is not installed."
+		Then I see "Stop! Candidate version is not installed. Please run:"
+		And I see ""
+		And I see "$ sdk install groovy 2.0.5"
 
 	Scenario: Default a candidate version that is installed and not default
 		Given the candidate "groovy" version "2.0.5" is a valid candidate version

--- a/src/test/resources/features/home.feature
+++ b/src/test/resources/features/home.feature
@@ -26,9 +26,12 @@ anything else unless it is an actual error.
 		Given the candidate "grails" version "1.3.9" is available for download
 		And the system is bootstrapped
 		When I enter "sdk home grails 1.3.9"
-		Then I see "Stop! Candidate version is not installed. Please run:"
-		And I see ""
-		And I see "$ sdk install grails 1.3.9"
+		Then I see "Stop! grails 1.3.9 is not available. Possible causes:"
+		And I see "* 1.3.9 is an invalid version"
+		And I see "* grails binaries are incompatible with LinuxX64"
+		And I see "* grails has not been released yet"
+		And I see "Tip: see all available versions for your platform:"
+		And I see "$ sdk list grails"
 		And the exit code is 1
 
 	Scenario: Home for a candidate version that does not exist

--- a/src/test/resources/features/home.feature
+++ b/src/test/resources/features/home.feature
@@ -26,7 +26,9 @@ anything else unless it is an actual error.
 		Given the candidate "grails" version "1.3.9" is available for download
 		And the system is bootstrapped
 		When I enter "sdk home grails 1.3.9"
-		Then I see "Stop! grails 1.3.9 is not installed."
+		Then I see "Stop! Candidate version is not installed. Please run:"
+		And I see ""
+		And I see "$ sdk install grails 1.3.9"
 		And the exit code is 1
 
 	Scenario: Home for a candidate version that does not exist

--- a/src/test/resources/features/use_version.feature
+++ b/src/test/resources/features/use_version.feature
@@ -23,7 +23,9 @@ Feature: Use Version
 		Given the candidate "groovy" version "1.9.9" is not available for download
 		And the system is bootstrapped
 		When I enter "sdk use groovy 1.9.9"
-		Then I see "Stop! groovy 1.9.9 is not installed."
+		Then I see "Stop! Candidate version is not installed. Please run:"
+		And I see ""
+		And I see "$ sdk install groovy 1.9.9"
 
 	Scenario: Use a candidate version that only exists locally
 		Given the candidate "grails" version "2.0.0.M1" is not available for download

--- a/src/test/resources/features/use_version.feature
+++ b/src/test/resources/features/use_version.feature
@@ -23,9 +23,12 @@ Feature: Use Version
 		Given the candidate "groovy" version "1.9.9" is not available for download
 		And the system is bootstrapped
 		When I enter "sdk use groovy 1.9.9"
-		Then I see "Stop! Candidate version is not installed. Please run:"
-		And I see ""
-		And I see "$ sdk install groovy 1.9.9"
+		Then I see "Stop! groovy 1.9.9 is not available. Possible causes:"
+		And I see "* 1.9.9 is an invalid version"
+		And I see "* groovy binaries are incompatible with LinuxX64"
+		And I see "* groovy has not been released yet"
+		And I see "Tip: see all available versions for your platform:"
+		And I see "$ sdk list groovy"
 
 	Scenario: Use a candidate version that only exists locally
 		Given the candidate "grails" version "2.0.0.M1" is not available for download


### PR DESCRIPTION
The message now adds an `sdk install` command to inform user how to correct the error.

This is useful when auto env is enabled, and user not aware their colleague has updated the candidate version. In some situation user isn't even aware of the presence of sdkman. All they see was just `Stop! java 15.0.2.fx is not installed`.

See more discussion about this PR in [this Slack thread](https://sdkman.slack.com/archives/CJK9DMV6V/p1611405973006900)