### PR TITLE
Add edit command to help output and Bash completion

### DIFF
--- a/contrib/completion/bash/sdk
+++ b/contrib/completion/bash/sdk
@@ -6,7 +6,7 @@ _sdk() {
 
 	case "$previous_word" in
 		sdk) 
-			candidates=("install" "uninstall" "list" "use" "completion" "default" "home" "env" "current" "upgrade" "version" "broadcast" "help" "offline" "selfupdate" "update" "flush")
+			candidates=("install" "uninstall" "list" "use" "completion" "edit" "default" "home" "env" "current" "upgrade" "version" "broadcast" "help" "offline" "selfupdate" "update" "flush")
 			;;
 		completion)
 			candidates=("bash" "zsh")

--- a/contrib/completion/bash/sdk
+++ b/contrib/completion/bash/sdk
@@ -5,8 +5,8 @@ _sdk() {
 	local candidates
 
 	case "$previous_word" in
-		sdk) 
-			candidates=("install" "uninstall" "list" "use" "completion" "edit" "default" "home" "env" "current" "upgrade" "version" "broadcast" "help" "offline" "selfupdate" "update" "flush")
+		sdk)
+			candidates=("install" "uninstall" "list" "use" "completion" "config" "default" "home" "env" "current" "upgrade" "version" "broadcast" "help" "offline" "selfupdate" "update" "flush")
 			;;
 		completion)
 			candidates=("bash" "zsh")

--- a/src/main/bash/sdkman-config.sh
+++ b/src/main/bash/sdkman-config.sh
@@ -16,7 +16,7 @@
 #   limitations under the License.
 #
 
-function __sdk_edit() {
+function __sdk_config() {
 	local -r editor=${EDITOR:=vi}
 
 	if ! command -v "$editor" > /dev/null; then

--- a/src/main/bash/sdkman-help.sh
+++ b/src/main/bash/sdkman-help.sh
@@ -27,7 +27,7 @@ function __sdk_help() {
 	__sdkman_echo_no_colour "       list      or ls   [candidate]"
 	__sdkman_echo_no_colour "       use       or u    <candidate> <version>"
 	__sdkman_echo_no_colour "       completion        <bash|zsh>"
-	__sdkman_echo_no_colour "       edit"
+	__sdkman_echo_no_colour "       config"
 	__sdkman_echo_no_colour "       default   or d    <candidate> [version]"
 	__sdkman_echo_no_colour "       home      or h    <candidate> <version>"
 	__sdkman_echo_no_colour "       env       or e    [init|install|clear]"

--- a/src/main/bash/sdkman-help.sh
+++ b/src/main/bash/sdkman-help.sh
@@ -27,6 +27,7 @@ function __sdk_help() {
 	__sdkman_echo_no_colour "       list      or ls   [candidate]"
 	__sdkman_echo_no_colour "       use       or u    <candidate> <version>"
 	__sdkman_echo_no_colour "       completion        <bash|zsh>"
+	__sdkman_echo_no_colour "       edit"
 	__sdkman_echo_no_colour "       default   or d    <candidate> [version]"
 	__sdkman_echo_no_colour "       home      or h    <candidate> <version>"
 	__sdkman_echo_no_colour "       env       or e    [init|install|clear]"

--- a/src/test/groovy/sdkman/specs/ConfigCommandSpec.groovy
+++ b/src/test/groovy/sdkman/specs/ConfigCommandSpec.groovy
@@ -2,7 +2,7 @@ package sdkman.specs
 
 import sdkman.support.SdkmanEnvSpecification
 
-class EditCommandSpec extends SdkmanEnvSpecification {
+class ConfigCommandSpec extends SdkmanEnvSpecification {
 	def "it should open the config in the system's default editor"() {
 		given:
 		bash = sdkmanBashEnvBuilder
@@ -15,7 +15,7 @@ class EditCommandSpec extends SdkmanEnvSpecification {
 
 		when:
 		setupEnv(bash)
-		bash.execute("sdk edit")
+		bash.execute("sdk config")
 
 		then:
 		verifyOutput(bash.output, sdkmanBaseDirectory)


### PR DESCRIPTION
This PR adds the `edit` command to the `help` output and the Bash completion.