### PR TITLE
Remove platform specific code, make tests more deterministic

### DIFF
--- a/src/main/bash/sdkman-current.sh
+++ b/src/main/bash/sdkman-current.sh
@@ -56,12 +56,8 @@ function __sdkman_determine_current_version() {
 	candidate="$1"
 	present=$(__sdkman_path_contains "${SDKMAN_CANDIDATES_DIR}/${candidate}")
 	if [[ "$present" == 'true' ]]; then
-		if [[ "$solaris" == true ]]; then
-			CURRENT=$(echo $PATH | gsed -r "s|${SDKMAN_CANDIDATES_DIR}/${candidate}/([^/]+)/bin|!!\1!!|1" | gsed -r "s|^.*!!(.+)!!.*$|\1|g")
-		elif [[ "$darwin" == true ]]; then
-			CURRENT=$(echo $PATH | sed -E "s|${SDKMAN_CANDIDATES_DIR}/${candidate}/([^/]+)/bin|!!\1!!|1" | sed -E "s|^.*!!(.+)!!.*$|\1|g")
-		else
-			CURRENT=$(echo $PATH | sed -r "s|${SDKMAN_CANDIDATES_DIR}/${candidate}/([^/]+)/bin|!!\1!!|1" | sed -r "s|^.*!!(.+)!!.*$|\1|g")
+		if [[ $PATH =~ ${SDKMAN_CANDIDATES_DIR}/${candidate}/([^/]+)/bin ]]; then
+			CURRENT=${BASH_REMATCH[1]}
 		fi
 
 		if [[ "$CURRENT" == "current" ]]; then

--- a/src/main/bash/sdkman-use.sh
+++ b/src/main/bash/sdkman-use.sh
@@ -37,15 +37,8 @@ function __sdk_use() {
 	# Just update the *_HOME and PATH for this shell.
 	__sdkman_set_candidate_home "$candidate" "$version"
 
-	# Replace the current path for the candidate with the selected version.
-	if [[ "$solaris" == true ]]; then
-		export PATH=$(echo $PATH | gsed -r "s!${SDKMAN_CANDIDATES_DIR}/${candidate}/([^/]+)!${SDKMAN_CANDIDATES_DIR}/${candidate}/${version}!g")
-
-	elif [[ "$darwin" == true ]]; then
-		export PATH=$(echo $PATH | sed -E "s!${SDKMAN_CANDIDATES_DIR}/${candidate}/([^/]+)!${SDKMAN_CANDIDATES_DIR}/${candidate}/${version}!g")
-
-	else
-		export PATH=$(echo "$PATH" | sed -r "s!${SDKMAN_CANDIDATES_DIR}/${candidate}/([^/]+)!${SDKMAN_CANDIDATES_DIR}/${candidate}/${version}!g")
+	if [[ $PATH =~ ${SDKMAN_CANDIDATES_DIR}/${candidate}/([^/]+) ]]; then
+		export PATH=${PATH//${SDKMAN_CANDIDATES_DIR}\/${candidate}\/${BASH_REMATCH[1]}/${SDKMAN_CANDIDATES_DIR}\/${candidate}\/${version}}
 	fi
 
 	if [[ ! (-L "${SDKMAN_CANDIDATES_DIR}/${candidate}/current" || -d "${SDKMAN_CANDIDATES_DIR}/${candidate}/current") ]]; then

--- a/src/test/groovy/sdkman/stubs/UnameStub.groovy
+++ b/src/test/groovy/sdkman/stubs/UnameStub.groovy
@@ -1,13 +1,11 @@
 package sdkman.stubs
 
-import sdkman.support.UnixUtils
-
 class UnameStub {
 
 	private File file
-	private platform = System.getProperty("os.name")
-	private machine = System.getProperty("os.arch")
-	private kernel = UnixUtils.asSdkmanPlatform(platform, machine)
+	private platform = "Linux"
+	private kernel = "Linux"
+	private machine = "X86_64"
 
 	static UnameStub prepareIn(File folder) {
 		folder.mkdirs()


### PR DESCRIPTION
Relates to #873.

After thinking a little bit about it, I had an idea to

* make the tests more deterministic
* remove platform specific code, which prevented the first point

A nice side effect of this change is, that a lot of commands (use, install, current) are also a little faster (around 90ms faster).
