### PR TITLE
Fix config command when using vscode

### DIFF
--- a/src/main/bash/sdkman-config.sh
+++ b/src/main/bash/sdkman-config.sh
@@ -17,14 +17,14 @@
 #
 
 function __sdk_config() {
-	local -r editor=${EDITOR:=vi}
+	local -r editor=(${EDITOR:=vi})
 
-	if ! command -v "$editor" > /dev/null; then
+	if ! command -v "${editor[@]}" > /dev/null; then
 		__sdkman_echo_red "No default editor configured."
 		__sdkman_echo_yellow "Please set the default editor with the EDITOR environment variable."
 
 		return 1
 	fi
 
-	"$editor" "${SDKMAN_DIR}/etc/config"
+	"${editor[@]}" "${SDKMAN_DIR}/etc/config"
 }

--- a/src/test/groovy/sdkman/specs/ConfigCommandSpec.groovy
+++ b/src/test/groovy/sdkman/specs/ConfigCommandSpec.groovy
@@ -23,11 +23,15 @@ class ConfigCommandSpec extends SdkmanEnvSpecification {
 		where:
 		setupEnv << [
 			{
-				it.execute('nano() { echo "nano was called with $1"; }')
+				it.execute('nano() { echo "nano was called with $*"; }')
 				it.execute("EDITOR=nano")
 			},
 			{
-				it.execute('vi() { echo "vi was called with $1"; }')
+				it.execute('code() { echo "code was called with $*"; }')
+				it.execute("EDITOR='code --wait'")
+			},
+			{
+				it.execute('vi() { echo "vi was called with $*"; }')
 				it.execute("unset EDITOR")
 			},
 			{
@@ -36,6 +40,7 @@ class ConfigCommandSpec extends SdkmanEnvSpecification {
 		]
 		verifyOutput << [
 			{ output, baseDirectory -> output.contains("nano was called with ${baseDirectory}/.sdkman/etc/config") },
+			{ output, baseDirectory -> output.contains("code was called with --wait ${baseDirectory}/.sdkman/etc/config") },
 			{ output, baseDirectory -> output.contains("vi was called with ${baseDirectory}/.sdkman/etc/config") },
 			{ output, _ -> output.contains("No default editor configured.") }
 		]


### PR DESCRIPTION
```sh-session
❯ echo $EDITOR
code --wait
❯ sdk config
No default editor configured.
Please set the default editor with the EDITOR environment variable.
```

The fix is to simply remove the double quotes, so the spaces in the env var expand as arguments instead of being interpreted as the path for the executable.