### PR TITLE
Add selfupdate_enable config and respect auto_answer when auto updating

### DIFF
--- a/src/main/bash/sdkman-main.sh
+++ b/src/main/bash/sdkman-main.sh
@@ -153,7 +153,7 @@ function sdk() {
 	fi
 
 	# Attempt upgrade after all is done
-	if [[ "$COMMAND" != "selfupdate" ]]; then
+	if [[ "$COMMAND" != "selfupdate" && "$sdkman_selfupdate_enable" == true ]]; then
 		__sdkman_auto_update "$SDKMAN_REMOTE_VERSION" "$SDKMAN_VERSION"
 	fi
 	return $final_rc

--- a/src/main/bash/sdkman-selfupdate.sh
+++ b/src/main/bash/sdkman-selfupdate.sh
@@ -48,7 +48,7 @@ function __sdkman_auto_update() {
 		__sdkman_echo_no_colour "The current version is $remote_version, but you have $version."
 		echo ""
 
-		if [[ "$sdkman_auto_selfupdate" != "true" ]]; then
+		if [[ "$sdkman_auto_answer" == false ]]; then
 			__sdkman_echo_confirm "Would you like to upgrade now? (Y/n): "
 			read upgrade
 		fi

--- a/src/test/resources/features/self_update.feature
+++ b/src/test/resources/features/self_update.feature
@@ -44,7 +44,7 @@ Feature: Self Update
 
 	Scenario: Automatically Selfupdate
 		Given an outdated initialised environment
-		And the configuration file has been primed with "sdkman_auto_selfupdate=true"
+		And the configuration file has been primed with "sdkman_auto_answer=true"
 		And the system is bootstrapped
 		When I enter "sdk help"
 		Then I see "A new version of SDKMAN is available..."
@@ -54,13 +54,21 @@ Feature: Self Update
 
 	Scenario: Do not automatically Selfupdate
 		Given an outdated initialised environment
-		And the configuration file has been primed with "sdkman_auto_selfupdate=false"
+		And the configuration file has been primed with "sdkman_auto_answer=false"
 		And the system is bootstrapped
 		When I enter "sdk help" and answer "n"
 		Then I see "A new version of SDKMAN is available..."
 		And I see "Would you like to upgrade now? (Y/n)"
 		And I see "Not upgrading today..."
 		And I do not see "Successfully upgraded SDKMAN."
+
+	Scenario: Do not check and prompt for update
+		Given an outdated initialised environment
+		And the configuration file has been primed with "sdkman_selfupdate_enable=false"
+		And the system is bootstrapped
+		When I enter "sdk help"
+		Then I do not see "A new version of SDKMAN is available..."
+		And I do not see "Would you like to upgrade now? (Y/n)"
 
 	Scenario: Bother the user with Upgrade message once a day
 		Given an outdated initialised environment


### PR DESCRIPTION
This also deprecates the auto_selfupdate config.

The automatic version check makes the things a lot harder to script in non-attended environments -- such as CI, as it keeps waiting for a response if an updated version is found.

Also, I use [my own tool to manage my updates system widely](https://github.com/felipecrs/dotfiles/blob/12d6701733071553fbe39c03cee3581e676d64c4/dot_local/bin/executable_full-upgrade#L148), which I run automatically. 

Fixes #925
Depends-On: https://github.com/sdkman/sdkman-hooks/pull/28
Depends-On: https://github.com/sdkman/sdkman-website/pull/49