### PR TITLE
fix for bash-4 (#923)

### DIFF
--- a/contrib/completion/bash/sdk
+++ b/contrib/completion/bash/sdk
@@ -32,9 +32,10 @@ __sdkman_complete_command() {
 			done
 			;;
 		install|list)
+		    curl --silent "${SDKMAN_CANDIDATES_API}/candidates/all" | \
 			while IFS= read -d, -r candidate; do
 				candidates+=($candidate)
-			done < <(curl --silent "${SDKMAN_CANDIDATES_API}/candidates/all")
+			done
 			;;
 		env)
 			candidates=("init install clear")


### PR DESCRIPTION
bash-4 does not support process substitution