### PR TITLE
Only run select GH steps and workflows on forks

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -16,6 +16,16 @@ jobs:
           - 27017:27017
     steps:
       - uses: actions/checkout@v2
+      - uses: sdkman/sdkman-action@master
+        id: sdkman
+        with:
+          candidate: java
+          version: 11.0.12-sem
+      - uses: actions/setup-java@v1
+        id: setup-java
+        with:
+          java-version: 11.0.12
+          jdkFile: ${{ steps.sdkman.outputs.file }}
       - name: Run tests
         run: ./gradlew clean test --info
       - name: Set short git hash

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -7,7 +7,6 @@ on:
 jobs:
   pre-release:
     name: "Beta Release"
-    if: github.repository == "sdkman/sdkman-cli"
     environment: production
     runs-on: "ubuntu-latest"
     services:
@@ -25,6 +24,7 @@ jobs:
       - name: Build artifacts
         run: ./gradlew -Penv=production -Phash=${{ steps.var.outputs.sha_short }} clean assemble
       - name: Release
+        if: github.repository == 'sdkman/sdkman-cli'
         uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
@@ -34,6 +34,7 @@ jobs:
           files: |
             build/distributions/sdkman-cli-*.zip
       - name: Update MongoDB
+        if: github.repository == 'sdkman/sdkman-cli'
         env:
           MONGO_URL: ${{ secrets.MONGO_URL }}
           MONGO_USERNAME: ${{ secrets.MONGO_USERNAME }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,7 +8,6 @@ jobs:
         uses: actions/checkout@v2
         with:
             ref: ${{ github.event.pull_request.head.sha }}
-
       - uses: sdkman/sdkman-action@master
         id: sdkman
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,16 @@ jobs:
           - 27017:27017
     steps:
     - uses: actions/checkout@v2
+        - uses: sdkman/sdkman-action@master
+          id: sdkman
+          with:
+            candidate: java
+            version: 11.0.12-sem
+        - uses: actions/setup-java@v1
+          id: setup-java
+          with:
+            java-version: 11.0.12
+            jdkFile: ${{ steps.sdkman.outputs.file }}
     - name: Run tests
       run: ./gradlew clean test --info
     - name: Set github tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     name: "Stable Release"
-    if: github.repository == "sdkman/sdkman-cli"
+    if: github.repository == 'sdkman/sdkman-cli'
     runs-on: ubuntu-latest
     environment: production
     services:


### PR DESCRIPTION
On forks:
* Run beta workflow without any release sections
* Do not run release workflow at all

Also, update workflows to use sdkman GH action to set Java version to Semeru 11.0.12