### PR TITLE
Reshape binary distribution to be SDK compliant

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,3 @@
-import org.apache.tools.ant.filters.ReplaceTokens
-
-import static org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
-
 plugins {
 	id('groovy')
 }
@@ -24,6 +20,8 @@ println("Release set to: $release")
 println("Candidtes API: $candidatesApi")
 println("Version: $sdkmanVersion")
 
+apply from: 'gradle/archive.gradle'
+
 repositories {
 	mavenCentral()
 }
@@ -45,72 +43,3 @@ dependencies {
 		exclude module: 'groovy-all'
 	}
 }
-
-task prepareScripts(type: Copy) {
-	from('src/main/bash')
-	into('build/scripts')
-	include('**/*')
-	filter(
-			ReplaceTokens,
-			tokens: [
-					SDKMAN_VERSION       : sdkmanVersion,
-					SDKMAN_CANDIDATES_API: candidatesApi
-			]
-	)
-}
-
-task prepareContrib(type: Copy) {
-	from('contrib')
-	into('build/contrib')
-}
-
-tasks.test.configure {
-	dependsOn(prepareScripts)
-	testLogging.exceptionFormat = FULL
-}
-
-task assembleArchive(type: Zip, dependsOn: [prepareScripts, prepareContrib]) {
-	archiveVersion = sdkmanVersion
-	from('build/scripts') {
-		include('*.sh*')
-	}
-	from('build') {
-		include('contrib/**')
-	}
-}
-
-tasks.assemble.configure {
-	dependsOn(assembleArchive)
-}
-
-task cleanInstallInit(type: Delete) {
-	delete(installBinDir)
-}
-
-task cleanContribInit(type: Delete) {
-	delete(installContribDir)
-}
-
-task cleanInstallModules(type: Delete) {
-	delete(installSrcDir)
-}
-
-task installContrib(type: Copy, dependsOn: [cleanContribInit, prepareContrib]) {
-	from('build/contrib')
-	into(installContribDir)
-}
-
-task installInit(type: Copy, dependsOn: [cleanInstallInit, prepareScripts]) {
-	from('build/scripts')
-	into(installBinDir)
-	include('sdkman-init.sh')
-}
-
-task installModules(type: Copy, dependsOn: [cleanInstallModules, prepareScripts]) {
-	from('build/scripts')
-	into(installSrcDir)
-	include('sdkman-*.sh')
-	exclude('sdkman-init.sh')
-}
-
-task install(dependsOn: [installInit, installContrib, installModules])

--- a/gradle/archive.gradle
+++ b/gradle/archive.gradle
@@ -1,0 +1,39 @@
+import org.apache.tools.ant.filters.ReplaceTokens
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+
+task prepareScripts(type: Copy) {
+	from('src/main/bash')
+	into('build/scripts')
+	include('**/*')
+	filter(
+			ReplaceTokens,
+			tokens: [
+					SDKMAN_VERSION       : sdkmanVersion,
+					SDKMAN_CANDIDATES_API: candidatesApi
+			]
+	)
+}
+
+task prepareContrib(type: Copy) {
+	from('contrib')
+	into('build/contrib')
+}
+
+tasks.test.configure {
+	dependsOn(prepareScripts)
+	testLogging.exceptionFormat = TestExceptionFormat.FULL
+}
+
+task assembleArchive(type: Zip, dependsOn: [prepareScripts, prepareContrib]) {
+	archiveVersion = sdkmanVersion
+	from('build/scripts') {
+		include('*.sh*')
+	}
+	from('build') {
+		include('contrib/**')
+	}
+}
+
+tasks.assemble.configure {
+	dependsOn(assembleArchive)
+}

--- a/gradle/archive.gradle
+++ b/gradle/archive.gradle
@@ -43,3 +43,7 @@ task assembleArchive(type: Zip, dependsOn: [prepareBin, prepareScripts, prepareC
 tasks.assemble.configure {
 	dependsOn(assembleArchive)
 }
+
+tasks.test.configure {
+	dependsOn(prepareBin, prepareScripts)
+}

--- a/gradle/archive.gradle
+++ b/gradle/archive.gradle
@@ -1,10 +1,19 @@
 import org.apache.tools.ant.filters.ReplaceTokens
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 
+def baseDir = "$buildDir/stage/sdkman-$release"
+
+task prepareBin(type: Copy) {
+	from('src/main/bash')
+	into("$baseDir/bin")
+	include('**/sdkman-init.sh')
+}
+
 task prepareScripts(type: Copy) {
 	from('src/main/bash')
-	into('build/scripts')
+	into("$baseDir/src")
 	include('**/*')
+	exclude('**/sdkman-init.sh')
 	filter(
 			ReplaceTokens,
 			tokens: [
@@ -16,7 +25,7 @@ task prepareScripts(type: Copy) {
 
 task prepareContrib(type: Copy) {
 	from('contrib')
-	into('build/contrib')
+	into("$baseDir/contrib")
 }
 
 tasks.test.configure {
@@ -24,13 +33,10 @@ tasks.test.configure {
 	testLogging.exceptionFormat = TestExceptionFormat.FULL
 }
 
-task assembleArchive(type: Zip, dependsOn: [prepareScripts, prepareContrib]) {
+task assembleArchive(type: Zip, dependsOn: [prepareBin, prepareScripts, prepareContrib]) {
 	archiveVersion = sdkmanVersion
-	from('build/scripts') {
-		include('*.sh*')
-	}
-	from('build') {
-		include('contrib/**')
+	from('build/stage') {
+		include('**/*')
 	}
 }
 

--- a/src/test/groovy/sdkman/env/SdkmanBashEnvBuilder.groovy
+++ b/src/test/groovy/sdkman/env/SdkmanBashEnvBuilder.groovy
@@ -139,10 +139,7 @@ class SdkmanBashEnvBuilder {
 			env.put("http_proxy", httpProxy)
 		}
 
-		def bashEnv = new BashEnv(baseFolder.absolutePath, env)
-		println("\nSdkmanBashEnvBuilder: $this")
-		println("\nBashEnv: $bashEnv")
-		bashEnv
+		new BashEnv(baseFolder.absolutePath, env)
 	}
 
 	private prepareDirectory(File target, String directoryName) {

--- a/src/test/groovy/sdkman/env/SdkmanBashEnvBuilder.groovy
+++ b/src/test/groovy/sdkman/env/SdkmanBashEnvBuilder.groovy
@@ -7,7 +7,9 @@ import sdkman.stubs.UnameStub
 @ToString(includeNames = true)
 class SdkmanBashEnvBuilder {
 
-	final TEST_SCRIPT_BUILD_DIR = "build/scripts" as File
+	final BUILD_STAGE_DIR = "build/stage/sdkman-latest"
+	final BUILD_BIN_DIR = "$BUILD_STAGE_DIR/bin"
+	final BUILD_SRC_DIR = "$BUILD_STAGE_DIR/src"
 
 	//mandatory fields
 	private final File baseFolder
@@ -183,7 +185,7 @@ class SdkmanBashEnvBuilder {
 	}
 
 	private primeInitScript(File targetFolder) {
-		def sourceInitScript = new File(TEST_SCRIPT_BUILD_DIR, 'sdkman-init.sh')
+		def sourceInitScript = new File(BUILD_BIN_DIR, 'sdkman-init.sh')
 
 		if (!sourceInitScript.exists())
 			throw new IllegalStateException("sdkman-init.sh has not been prepared for consumption.")
@@ -194,7 +196,7 @@ class SdkmanBashEnvBuilder {
 	}
 
 	private primeModuleScripts(File targetFolder) {
-		for (f in TEST_SCRIPT_BUILD_DIR.listFiles()) {
+		for (f in new File(BUILD_SRC_DIR).listFiles()) {
 			if (!(f.name in ['selfupdate.sh', 'install.sh', 'sdkman-init.sh'])) {
 				new File(targetFolder, f.name) << f.text
 			}


### PR DESCRIPTION
This PR reshapes the binary zip so that it may be extracted in-place during the installation process.

- Extract custom archive tasks to gradle folder.
- Prepare and consume files in new stage build folder.
- Add test task dependency on script prep tasks.
- Silence noisy logs.
