### PR TITLE
Considering env var ZSH_DISABLE_COMPFIX during initialization

### DIFF
--- a/src/main/bash/sdkman-init.sh
+++ b/src/main/bash/sdkman-init.sh
@@ -181,7 +181,11 @@ if [[ "$sdkman_auto_complete" == 'true' ]]; then
 		# initialize zsh completions (if not already done)
 		if ! (( $+functions[compdef] )) ; then
 			autoload -Uz compinit
-			compinit
+			if [[ $ZSH_DISABLE_COMPFIX == 'true' ]]; then
+				compinit -u -C
+			else
+				compinit
+			fi
 		fi
 		source "${SDKMAN_DIR}/contrib/completion/zsh/sdk"
 		__sdkman_echo_debug "ZSH completion script loaded..."


### PR DESCRIPTION
This PR provides a fix for #938 by considering the environment variable `ZSH_DISABLE_COMPFIX`.

By default, on initialization `compinit` is called like before. That means `compaudit` is called and security checks are performed. This might block the shell, waiting for user input. Especially this is not desired in the presence of non-interactive shells. Another scenario, in which security checks might not be desired is a multi-user system. For security reasons, `compinit` requires completion directories to be owned by the same user who runs the command.

If we set `ZSH_DISABLE_COMPFIX="true"`, then `compinit -u -C` is called. Effectively, `-C` will skip all security checks and `-u` will use all files found for completion (see [compinit](https://github.com/zsh-users/zsh/blob/82ff9f24f170eea7daa935fdaa09ab75a2f277ff/Completion/compinit#L67-L72)). This is considered best practice in [oh-my-zsh](https://github.com/ohmyzsh/ohmyzsh/blob/28ee5846bbac56926241fc5ef9f116161ceb6f23/oh-my-zsh.sh#L80-L81).

**Note:** this might need to be mentioned in the [sdkman.io docs](https://github.com/sdkman/sdkman-website/blob/master/app/views/install.scala.html)