### PR TITLE
Add trailing newline character to the home command

### DIFF
--- a/src/main/bash/sdkman-home.sh
+++ b/src/main/bash/sdkman-home.sh
@@ -35,5 +35,5 @@ function __sdk_home() {
 		return 1
 	fi
 
-	echo -n "${SDKMAN_CANDIDATES_DIR}/${candidate}/${version}"
+	echo "${SDKMAN_CANDIDATES_DIR}/${candidate}/${version}"
 }


### PR DESCRIPTION
This PR fixes [965](https://github.com/sdkman/sdkman-cli/issues/965) bug.