### PR TITLE
Display a warning when Bash is run in POSIX mode

### DIFF
--- a/contrib/completion/bash/sdk
+++ b/contrib/completion/bash/sdk
@@ -32,9 +32,11 @@ __sdkman_complete_command() {
 			done
 			;;
 		install|list)
-			while IFS= read -d, -r candidate; do
+			local candidates_csv=$(curl --silent "${SDKMAN_CANDIDATES_API}/candidates/all")
+
+			while read -r -d, candidate; do
 				candidates+=($candidate)
-			done < <(curl --silent "${SDKMAN_CANDIDATES_API}/candidates/all")
+			done <<< "$candidates_csv"
 			;;
 		env)
 			candidates=("init install clear")
@@ -71,9 +73,11 @@ __sdkman_complete_candidate_version() {
 			done
 			;;
 		install)
+			local versions_csv=$(curl --silent "${SDKMAN_CANDIDATES_API}/candidates/$candidate/${SDKMAN_PLATFORM}/versions/all")
+
 			while IFS= read -d, -r version; do
 				candidates+=($version)
-			done < <(curl --silent "${SDKMAN_CANDIDATES_API}/candidates/$candidate/${SDKMAN_PLATFORM}/versions/all")
+			done <<< "$versions_csv"
 			;;
 	esac
 

--- a/contrib/completion/bash/sdk
+++ b/contrib/completion/bash/sdk
@@ -32,10 +32,9 @@ __sdkman_complete_command() {
 			done
 			;;
 		install|list)
-		    curl --silent "${SDKMAN_CANDIDATES_API}/candidates/all" | \
 			while IFS= read -d, -r candidate; do
 				candidates+=($candidate)
-			done
+			done < <(curl --silent "${SDKMAN_CANDIDATES_API}/candidates/all")
 			;;
 		env)
 			candidates=("init install clear")
@@ -72,10 +71,9 @@ __sdkman_complete_candidate_version() {
 			done
 			;;
 		install)
-		    curl --silent "${SDKMAN_CANDIDATES_API}/candidates/$candidate/${SDKMAN_PLATFORM}/versions/all" | \
 			while IFS= read -d, -r version; do
 				candidates+=($version)
-			done
+			done < <(curl --silent "${SDKMAN_CANDIDATES_API}/candidates/$candidate/${SDKMAN_PLATFORM}/versions/all")
 			;;
 	esac
 

--- a/src/main/bash/sdkman-init.sh
+++ b/src/main/bash/sdkman-init.sh
@@ -135,7 +135,7 @@ done
 IFS="$OLD_IFS"
 unset OLD_IFS scripts f
 
-if [[ $POSIXLY_CORRECT == "y" ]]; then
+if [[ "$POSIXLY_CORRECT" == 'y' ]]; then
   __sdkman_echo_yellow "It seems you are running Bash in POSIX mode. While some of SDKMAN!s functionality may still work, it is strongly recommended to run Bash without any compatibility flags turned on."
 fi
 
@@ -193,7 +193,7 @@ if [[ "$sdkman_auto_complete" == 'true' ]]; then
 		fi
 		source "${SDKMAN_DIR}/contrib/completion/zsh/sdk"
 		__sdkman_echo_debug "ZSH completion script loaded..."
-	elif [[ "$bash_shell" == 'true' ]] && [[ $POSIXLY_CORRECT != 'y' ]]; then
+	elif [[ "$bash_shell" == 'true' ]] && [[ "$POSIXLY_CORRECT" != 'y' ]]; then
 		source "${SDKMAN_DIR}/contrib/completion/bash/sdk"
 		__sdkman_echo_debug "Bash completion script loaded..."
 	else

--- a/src/main/bash/sdkman-init.sh
+++ b/src/main/bash/sdkman-init.sh
@@ -193,7 +193,7 @@ if [[ "$sdkman_auto_complete" == 'true' ]]; then
 		fi
 		source "${SDKMAN_DIR}/contrib/completion/zsh/sdk"
 		__sdkman_echo_debug "ZSH completion script loaded..."
-	elif [[ "$bash_shell" == 'true' ]] && [[ "$POSIXLY_CORRECT" != 'y' ]]; then
+	elif [[ "$bash_shell" == 'true' ]]; then
 		source "${SDKMAN_DIR}/contrib/completion/bash/sdk"
 		__sdkman_echo_debug "Bash completion script loaded..."
 	else

--- a/src/main/bash/sdkman-init.sh
+++ b/src/main/bash/sdkman-init.sh
@@ -135,6 +135,10 @@ done
 IFS="$OLD_IFS"
 unset OLD_IFS scripts f
 
+if [[ $POSIXLY_CORRECT == "y" ]]; then
+  __sdkman_echo_yellow "It seems you are running Bash in POSIX mode. While some of SDKMAN!s functionality may still work, it is strongly recommended to run Bash without any compatibility flags turned on."
+fi
+
 # Create upgrade delay file if it doesn't exist
 if [[ ! -f "${SDKMAN_DIR}/var/delay_upgrade" ]]; then
 	touch "${SDKMAN_DIR}/var/delay_upgrade"
@@ -189,7 +193,7 @@ if [[ "$sdkman_auto_complete" == 'true' ]]; then
 		fi
 		source "${SDKMAN_DIR}/contrib/completion/zsh/sdk"
 		__sdkman_echo_debug "ZSH completion script loaded..."
-	elif [[ "$bash_shell" == 'true' ]]; then
+	elif [[ "$bash_shell" == 'true' ]] && [[ $POSIXLY_CORRECT != 'y' ]]; then
 		source "${SDKMAN_DIR}/contrib/completion/bash/sdk"
 		__sdkman_echo_debug "Bash completion script loaded..."
 	else

--- a/src/main/bash/sdkman-init.sh
+++ b/src/main/bash/sdkman-init.sh
@@ -135,7 +135,7 @@ done
 IFS="$OLD_IFS"
 unset OLD_IFS scripts f
 
-if [[ "$POSIXLY_CORRECT" == 'y' ]]; then
+if [[ "$POSIXLY_CORRECT" == 'y' ]]; then
   __sdkman_echo_yellow "It seems you are running Bash in POSIX mode. While some of SDKMAN!s functionality may still work, it is strongly recommended to run Bash without any compatibility flags turned on."
 fi
 

--- a/src/test/groovy/sdkman/specs/InitialisationSpec.groovy
+++ b/src/test/groovy/sdkman/specs/InitialisationSpec.groovy
@@ -107,6 +107,18 @@ class InitialisationSpec extends SdkmanEnvSpecification {
 		duplicateCandidates.isEmpty()
 	}
 
+	void "should display a warning if Bash is run in POSIX mode"() {
+		given:
+		bash.start()
+
+		when:
+		bash.execute("POSIXLY_CORRECT=y")
+		bash.execute("source $bootstrapScript")
+
+		then:
+		bash.output.contains("It seems you are running Bash in POSIX mode.")
+	}
+
 	private prepareCandidateDirectories(List candidates) {
 		candidates.forEach {
 			def current = Paths.get("$candidatesDirectory/$it/current")


### PR DESCRIPTION
When SDKMAN! is run in [POSIX mode](https://www.gnu.org/software/bash/manual/html_node/Bash-POSIX-Mode.html), a warning should be displayed and Bash completion turned off.