### PR TITLE
Introduce beta api for latest build

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -26,7 +26,7 @@ jobs:
         id: var
         run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
       - name: Build artifacts
-        run: ./gradlew -Penv=production -Phash=${{ steps.var.outputs.sha_short }} clean assemble
+        run: ./gradlew -Penv=beta -Phash=${{ steps.var.outputs.sha_short }} clean assemble
       - name: Release
         if: github.repository == 'sdkman/sdkman-cli'
         uses: "marvinpinto/action-automatic-releases@latest"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       id: var
       run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
     - name: Build artifacts
-      run: ./gradlew -Penv=production -Prelease=${{ steps.var.outputs.tag }} clean assemble
+      run: ./gradlew -Penv=stable -Prelease=${{ steps.var.outputs.tag }} clean assemble
     - name: Release
       uses: ncipollo/release-action@v1
       with:

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,14 @@ ext.installContribDir = "${userHome}/.sdkman/contrib"
 ext.environment = hasProperty('env') ? env : 'local'
 ext.hash = hasProperty('hash') ? hash : 'hashme'
 ext.release = hasProperty('release') ? release : 'latest'
-ext.candidatesApi = ext.environment == 'production' ? 'https://api.sdkman.io/2' : 'http://localhost:8080/2'
+
+if ("$environment" == 'stable') {
+	ext.candidatesApi = 'https://api.sdkman.io/2'
+} else if ("$environment" == 'beta') {
+	ext.candidatesApi = 'https://beta.sdkman.io/2'
+} else {
+	ext.candidatesApi = 'http://localhost:8080/2'
+}
 
 ext.sdkmanVersion = ext.release == 'latest' ? "latest+${ext.hash}".toString() : ext.release
 

--- a/src/main/bash/sdkman-selfupdate.sh
+++ b/src/main/bash/sdkman-selfupdate.sh
@@ -26,8 +26,7 @@ function __sdk_selfupdate() {
 		echo "No update available at this time."
 	else
 		export sdkman_debug_mode
-		export sdkman_beta_channel
-		__sdkman_secure_curl "${SDKMAN_CANDIDATES_API}/selfupdate?beta=${sdkman_beta_channel}" | bash
+		__sdkman_secure_curl "${SDKMAN_CANDIDATES_API}/selfupdate" | bash
 	fi
 
 	unset SDKMAN_FORCE_SELFUPDATE


### PR DESCRIPTION
- Pass release channel from GitHub actions to build as env parameter.
- Drop beta query parameter on selfupdate.
