### PR TITLE
Make Bash completion work with POSIX mode

### DIFF
--- a/contrib/completion/bash/sdk
+++ b/contrib/completion/bash/sdk
@@ -73,7 +73,7 @@ __sdkman_complete_candidate_version() {
 			done
 			;;
 		install)
-			local -r all_candidate_versions =$(curl --silent "${SDKMAN_CANDIDATES_API}/candidates/$candidate/${SDKMAN_PLATFORM}/versions/all")
+			local -r all_candidate_versions=$(curl --silent "${SDKMAN_CANDIDATES_API}/candidates/$candidate/${SDKMAN_PLATFORM}/versions/all")
 
 			while IFS= read -d, -r version; do
 				candidates+=($version)

--- a/contrib/completion/bash/sdk
+++ b/contrib/completion/bash/sdk
@@ -32,10 +32,11 @@ __sdkman_complete_command() {
 			done
 			;;
 		install|list)
-		    curl --silent "${SDKMAN_CANDIDATES_API}/candidates/all" | \
+			local -r all_candidates=$(curl --silent "${SDKMAN_CANDIDATES_API}/candidates/all")
+
 			while IFS= read -d, -r candidate; do
 				candidates+=($candidate)
-			done
+			done <<< "$all_candidates"
 			;;
 		env)
 			candidates=("init install clear")
@@ -72,10 +73,11 @@ __sdkman_complete_candidate_version() {
 			done
 			;;
 		install)
-		    curl --silent "${SDKMAN_CANDIDATES_API}/candidates/$candidate/${SDKMAN_PLATFORM}/versions/all" | \
+			local -r all_candidate_versions =$(curl --silent "${SDKMAN_CANDIDATES_API}/candidates/$candidate/${SDKMAN_PLATFORM}/versions/all")
+
 			while IFS= read -d, -r version; do
 				candidates+=($version)
-			done
+			done <<< "$all_candidate_versions"
 			;;
 	esac
 

--- a/src/test/groovy/sdkman/env/BashEnv.groovy
+++ b/src/test/groovy/sdkman/env/BashEnv.groovy
@@ -46,7 +46,7 @@ class BashEnv {
 	 * Starts the external bash process.
 	 */
 	void start() {
-		process = ["bash", "--noprofile", "--norc", "-i", "-o", "noclobber"].execute(env, workDir)
+		process = ["bash", "--noprofile", "--norc", "--posix", "-i", "-o", "noclobber"].execute(env, workDir)
 
 		consumeProcessStream(process.inputStream)
 		consumeProcessStream(process.errorStream)


### PR DESCRIPTION
Tests are now run with the `--posix` flag by default, to detect cases where something would break in POSIX mode.

Strangely enough, POSIX mode does not disable all of Bash's functionality, so things like `here strings` work. And on Bash 5.x, even process substitution works 😕.