### PR TITLE
Add trailing newline character in java home command

### DIFF
--- a/src/main/bash/sdkman-home.sh
+++ b/src/main/bash/sdkman-home.sh
@@ -35,5 +35,10 @@ function __sdk_home() {
 		return 1
 	fi
 
-	echo -n "${SDKMAN_CANDIDATES_DIR}/${candidate}/${version}"
+		
+	if [[ "$sdkman_home_newline" == "false" ]]; then
+    	echo -n "${SDKMAN_CANDIDATES_DIR}/${candidate}/${version}"
+    else
+    	echo "${SDKMAN_CANDIDATES_DIR}/${candidate}/${version}"
+	fi
 }


### PR DESCRIPTION
This PR fixes [965](https://github.com/sdkman/sdkman-cli/issues/965) bug.

Need to update config file loaded on sdk install