### PR TITLE
Fix bash completion of candidates for install

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If the environment needs tweaking for SDKMAN to be installed, the installer will
 
 ## Running the Cucumber Features
 
-All SDKMAN's BDD tests describing the CLI behaviour are written in Cucumber and can be found under `src/test/cucumber/sdkman`. These can be run with Gradle by running the following command:
+All SDKMAN's BDD tests describing the CLI behaviour are written in Cucumber and can be found under `src/test/resources/features`. These can be run with Gradle by running the following command:
 
     $ ./gradlew test
 

--- a/contrib/completion/bash/sdk
+++ b/contrib/completion/bash/sdk
@@ -18,7 +18,7 @@ __sdkman_complete_command() {
 	local -r command=$1
 	local -r current_word=$2
 
-	local candidates
+	local -a candidates
 
 	case $command in
 		sdk)
@@ -33,10 +33,7 @@ __sdkman_complete_command() {
 			;;
 		install|list)
 			local -r all_candidates=$(curl --silent "${SDKMAN_CANDIDATES_API}/candidates/all")
-
-			while IFS= read -d, -r candidate; do
-				candidates+=($candidate)
-			done <<< "$all_candidates"
+			IFS=',' read -r -a candidates <<< "$all_candidates"
 			;;
 		env)
 			candidates=("init install clear")
@@ -60,7 +57,7 @@ __sdkman_complete_candidate_version() {
 	local -r candidate=$2
 	local -r candidate_version=$3
 
-	local candidates
+	local -a candidates
 
 	case $command in
 		use|default|home|uninstall)
@@ -74,10 +71,7 @@ __sdkman_complete_candidate_version() {
 			;;
 		install)
 			local -r all_candidate_versions=$(curl --silent "${SDKMAN_CANDIDATES_API}/candidates/$candidate/${SDKMAN_PLATFORM}/versions/all")
-
-			while IFS= read -d, -r version; do
-				candidates+=($version)
-			done <<< "$all_candidate_versions"
+			IFS=',' read -r -a candidates <<< "$all_candidate_versions"
 			;;
 	esac
 


### PR DESCRIPTION
Fixes #992 

The `read` built-in uses `IFS` for word delimiters, and `-d` for delimiting _where to stop reading_ (default to line separator). We are parsing CSV, so the combination of `IFS= -d,` results in only the first word.

For example:

```shell
$ declare -a sdkcandidates
$ IFS= read -d, -r -a sdkcandidates < $SDKMAN_CANDIDATES_CACHE
$ declare -p sdkcandidates
declare -a sdkcandidates=([0]="activemq")

# vs.

$ unset sdkcandidates
$ declare -a sdkcandidates
$ IFS=, read -r -a sdkcandidates < $SDKMAN_CANDIDATES_CACHE
$ declare -p sdkcandidates
declare -a sdkcandidates=([0]="activemq" [1]="ant" [2]="asciidoctorj" [3]="ballerina" [4]="bpipe" [5]="btrace" [6]="concurnas" [7]="connor" [8]="cuba" [9]="cxf" [10]="doctoolchain" [11]="flink" [12]="gaiden" [13]="gradle" [14]="gradleprofiler" [15]="grails" [16]="groovy" [17]="groovyserv" [18]="hadoop" [19]="http4k" [20]="infrastructor" [21]="java" [22]="jbake" [23]="jbang" [24]="jmc" [25]="jmeter" [26]="jreleaser" [27]="karaf" [28]="kotlin" [29]="kscript" [30]="layrry" [31]="leiningen" [32]="maven" [33]="micronaut" [34]="mulefd" [35]="mvnd" [36]="pomchecker" [37]="quarkus" [38]="sbt" [39]="scala" [40]="spark" [41]="springboot" [42]="sshoogr" [43]="test" [44]="tomcat" [45]="vertx" [46]="visualvm" [47]="webtau" [48]="znai")
```

Further, `read -a` fills an array variable so we don't need a loop.