### PR TITLE
Fix test errors after commit 8c889a5 (bash completion w/posix)

### DIFF
--- a/src/test/groovy/sdkman/steps/command_line_interop_steps.groovy
+++ b/src/test/groovy/sdkman/steps/command_line_interop_steps.groovy
@@ -48,5 +48,5 @@ And(~'the "(.*)" variable is not set') { String home ->
 
 And(~'^the home path ends with \"([^\"]*)\"$') { String suffix ->
 	def path = sdkmanBaseDir.absolutePath + "/" + suffix
-	assert result.trim().equals(path)
+	assert result.trim().endsWith(path)
 }


### PR DESCRIPTION
macOS Big Sur 11.6 (20G165)

When running `./gradlew clean test` I see these errors:

```bash
sdkman.cucumber.RunCukeTests > Print home path.Home for a candidate version that is installed FAILED
    Assertion failed: 

    assert result.trim().equals(path)
           |      |      |      |
           |      |      false  /tmp/sdkman-test/03e2f1a2-f092-40ef-a806-e3bf110d86cc/.sdkman/candidates/grails/1.3.9
           |      -n /tmp/sdkman-test/03e2f1a2-f092-40ef-a806-e3bf110d86cc/.sdkman/candidates/grails/1.3.9
        
           -n /tmp/sdkman-test/03e2f1a2-f092-40ef-a806-e3bf110d86cc/.sdkman/candidates/grails/1.3.9
        at sdkman.steps.command_line_interop_steps$_run_closure11.doCall(command_line_interop_steps.groovy:51)
        at ✽.the home path ends with ".sdkman/candidates/grails/1.3.9"(file:src/test/resources/features/home.feature:23)

sdkman.cucumber.RunCukeTests > Print home path.Home for a candidate version that only exists locally FAILED
    Assertion failed: 

    assert result.trim().equals(path)
           |      |      |      |
           |      |      false  /tmp/sdkman-test/03e2f1a2-f092-40ef-a806-e3bf110d86cc/.sdkman/candidates/grails/2.0.0.M1
           |      -n /tmp/sdkman-test/03e2f1a2-f092-40ef-a806-e3bf110d86cc/.sdkman/candidates/grails/2.0.0.M1
        
           -n /tmp/sdkman-test/03e2f1a2-f092-40ef-a806-e3bf110d86cc/.sdkman/candidates/grails/2.0.0.M1
        at sdkman.steps.command_line_interop_steps$_run_closure11.doCall(command_line_interop_steps.groovy:51)
        at ✽.the home path ends with ".sdkman/candidates/grails/2.0.0.M1"(file:src/test/resources/features/home.feature:45)

sdkman.cucumber.RunCukeTests > Mnemonics.Shortcut for displaying Home directory FAILED
    Assertion failed: 

    assert result.trim().equals(path)
           |      |      |      |
           |      |      false  /tmp/sdkman-test/03e2f1a2-f092-40ef-a806-e3bf110d86cc/.sdkman/candidates/grails/2.1.0
           |      -n /tmp/sdkman-test/03e2f1a2-f092-40ef-a806-e3bf110d86cc/.sdkman/candidates/grails/2.1.0
        
           -n /tmp/sdkman-test/03e2f1a2-f092-40ef-a806-e3bf110d86cc/.sdkman/candidates/grails/2.1.0
        at sdkman.steps.command_line_interop_steps$_run_closure11.doCall(command_line_interop_steps.groovy:51)
        at ✽.the home path ends with ".sdkman/candidates/grails/2.1.0"(file:src/test/resources/features/mnemonics.feature:96)
```

I'm not entirely sure where the extra **-n** is coming from, but changing the assertion from `equals` to `endsWith` makes the test pass.