### PR TITLE
Configure releases via JReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,22 @@
 name: Release
-on: 
-  push:
-    tags:
-    - '*'
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version"
+        required: true
 jobs:
   build:
     name: "Stable Release"
     if: github.repository == 'sdkman/sdkman-cli'
     runs-on: ubuntu-latest
     environment: production
+    env:
+      JRELEASER_GITHUB_TOKEN: ${{ github.token }}
+      JRELEASER_TWITTER_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_API_KEY }}
+      JRELEASER_TWITTER_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_API_SECRET }}
+      JRELEASER_TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
+      JRELEASER_TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
     services:
       mongodb:
         image: mongo:3.2
@@ -22,33 +30,16 @@ jobs:
         java-version: '11'
     - name: Run tests
       run: ./gradlew clean test --info
-    - name: Set github tag
-      id: var
-      run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
     - name: Build artifacts
-      run: ./gradlew -Penv=stable -Prelease=${{ steps.var.outputs.tag }} clean assemble
+      run: ./gradlew -Penv=stable -Prelease=${{ github.event.inputs.version }} clean assemble
     - name: Release
-      uses: ncipollo/release-action@v1
-      with:
-        artifacts: "build/distributions/sdkman-cli-*.zip"
-        token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Get release
-      id: get_release
-      uses: bruceadams/get-release@v1.2.2
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
+      run: ./gradlew -Penv=stable -Prelease=${{ github.event.inputs.version }} jreleaserRelease
     - name: Update MongoDB
       env:
         MONGO_URL: ${{ secrets.MONGO_URL }}
         MONGO_USERNAME: ${{ secrets.MONGO_USERNAME }}
         MONGO_PASSWORD: ${{ secrets.MONGO_PASSWORD }}
-        RELEASE_TAG: ${{ steps.var.outputs.tag }}
+        RELEASE_TAG: ${{ github.event.inputs.version }}
       run: bin/release-binary.sh "$MONGO_URL" "$MONGO_USERNAME" "$MONGO_PASSWORD" "$RELEASE_TAG" "stable"
     - name: Tweet about it
-      uses: ethomson/send-tweet-action@v1
-      with:
-        status: "Released version ${{ steps.get_release.outputs.tag_name }} of SDKMAN! ${{ steps.get_release.outputs.html_url }}"
-        consumer-key: ${{ secrets.TWITTER_CONSUMER_API_KEY }}
-        consumer-secret: ${{ secrets.TWITTER_CONSUMER_API_SECRET }}
-        access-token: ${{ secrets.TWITTER_ACCESS_TOKEN }}
-        access-token-secret: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+      run: ./gradlew -Penv=stable -Prelease=${{ github.event.inputs.version }} jreleaserAnnounce

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
 	id('groovy')
+	id('org.jreleaser').version('0.8.0').apply(false)
 }
 
 String userHome = System.getProperty('user.home')
@@ -24,10 +25,11 @@ ext.sdkmanVersion = ext.release == 'latest' ? "latest+${ext.hash}".toString() : 
 println("Environment is set to: $environment")
 println("Short git hash: $hash")
 println("Release set to: $release")
-println("Candidtes API: $candidatesApi")
+println("Candidates API: $candidatesApi")
 println("Version: $sdkmanVersion")
 
 apply from: 'gradle/archive.gradle'
+apply from: 'gradle/release.gradle'
 
 repositories {
 	mavenCentral()

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -1,0 +1,44 @@
+apply plugin: 'org.jreleaser'
+
+jreleaser {
+	project {
+		name = 'sdkman-cli'
+		version = sdkmanVersion
+		description = 'Sdkman - The Software Development Kit Manager'
+		website = 'https://sdkman.io'
+		authors = ['Marco Vermeulen']
+		license = 'Apache-2.0'
+		extraProperties.put('inceptionYear', '2012')
+	}
+	
+	release {
+		github {
+			overwrite = true
+			tagName = '{{projectVersion}}'
+			skipTag = true
+			changelog {
+				formatted = 'ALWAYS'
+				format = '- {{commitShortHash}} {{commitTitle}}'
+				contributors {
+					format = '- {{contributorName}}'
+				}
+				contentTemplate = file('src/jreleaser/changelog.tpl')
+				hide {
+					contributors = ['GitHub']
+				}
+			}
+		}
+	}
+	
+	distributions {
+		'sdkman-cli' {
+			distributionType = 'BINARY'
+			artifact {
+				path = "build/distributions/{{distributionName}}-${sdkmanVersion}.zip"
+			}
+			sdkman {
+				active = 'RELEASE'
+			}
+		}
+	}
+}

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -15,7 +15,6 @@ jreleaser {
 		github {
 			overwrite = true
 			tagName = '{{projectVersion}}'
-			skipTag = true
 			changelog {
 				formatted = 'ALWAYS'
 				format = '- {{commitShortHash}} {{commitTitle}}'
@@ -36,9 +35,13 @@ jreleaser {
 			artifact {
 				path = "build/distributions/{{distributionName}}-${sdkmanVersion}.zip"
 			}
-			sdkman {
-				active = 'RELEASE'
-			}
+		}
+	}
+
+	announce {
+		twitter {
+			active = 'RELEASE'
+			status = 'Released version {{tagName}} of SDKMAN! {{releaseNotesUrl}}'
 		}
 	}
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,9 @@
+pluginManagement {
+	repositories {
+		mavenLocal()
+		gradlePluginPortal()
+		mavenCentral()
+	}
+}
+
 rootProject.name = "sdkman-cli"

--- a/src/jreleaser/changelog.tpl
+++ b/src/jreleaser/changelog.tpl
@@ -1,0 +1,6 @@
+LOREM IPSUM DOLOR SIT AMET
+
+## Changelog
+
+{{changelogChanges}}
+{{changelogContributors}}


### PR DESCRIPTION
Adds JReleaser configuration in a secondary script named `release.gradle`
Updates the `release.yml` workflow to tag, release, and tweet. It's now triggered as a workflow dispatch, taking the release version as input.

The ` src/jreleaser/changelog.tpl ` template file may be updated before a release to accommodate additional release notes besides the full changelog.