### PR TITLE
Add /usr/local/bin to test PATH

### DIFF
--- a/src/test/groovy/sdkman/env/BashEnv.groovy
+++ b/src/test/groovy/sdkman/env/BashEnv.groovy
@@ -33,7 +33,7 @@ class BashEnv {
 	BashEnv(workDir, Map env) {
 		this.workDir = workDir as File
 
-		def basicPath = "/usr/sbin:/usr/bin:/sbin:/bin"
+		def basicPath = "/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 		def localBinDir = "${workDir}/bin"
 
 		def modifiedPath = "$localBinDir:$basicPath"


### PR DESCRIPTION
Add /usr/local/bin to default PATH, so user-installed utils (like md5sum in OSX) are picked up during tests