### PR TITLE
Fix #1038: Consider unsupported platforms as exotic

### DIFF
--- a/src/main/bash/sdkman-init.sh
+++ b/src/main/bash/sdkman-init.sh
@@ -63,11 +63,8 @@ function infer_platform() {
 	  aarch64)
 		echo "LinuxARM64"
 		;;
-	  alpha | i64 | ppc | ppc64le | ppc64el | s390 | s390x)
-		echo "exotic"
-		;;
 	  *)
-	  	echo "LinuxX64"
+	  	echo "Exotic"
 	  	;;
 	  esac
 	  ;;

--- a/src/main/bash/sdkman-init.sh
+++ b/src/main/bash/sdkman-init.sh
@@ -63,6 +63,9 @@ function infer_platform() {
 	  aarch64)
 		echo "LinuxARM64"
 		;;
+	  alpha | i64 | ppc | ppc64le | ppc64el | s390 | s390x)
+		echo "exotic"
+		;;
 	  *)
 	  	echo "LinuxX64"
 	  	;;

--- a/src/test/groovy/sdkman/specs/PlatformSpec.groovy
+++ b/src/test/groovy/sdkman/specs/PlatformSpec.groovy
@@ -26,12 +26,13 @@ class PlatformSpec extends SdkmanEnvSpecification {
 		"Linux"  | "armv7l"  | "linuxarm32hf"
 		"Linux"  | "armv8l"  | "linuxarm32hf"
 		"Linux"  | "aarch64" | "linuxarm64"
-		"Linux"  | ""        | "linuxx64"
+		"Linux"  | ""        | "exotic"
 		"Darwin" | "x86_64"  | "darwinx64"
 		"Darwin" | "arm64"   | "darwinarm64"
 		"Darwin" | ""        | "darwinx64"
 		"MSYS64" | "i686"    | "msys64"
 		"MSYS64" | ""        | "msys64"
+    "Linux"  | "ppc64le" | "exotic"
 	}
 
 	def "should enable rosetta 2 compatibility mode with environment variable"() {

--- a/src/test/groovy/sdkman/specs/PlatformSpec.groovy
+++ b/src/test/groovy/sdkman/specs/PlatformSpec.groovy
@@ -26,13 +26,19 @@ class PlatformSpec extends SdkmanEnvSpecification {
 		"Linux"  | "armv7l"  | "linuxarm32hf"
 		"Linux"  | "armv8l"  | "linuxarm32hf"
 		"Linux"  | "aarch64" | "linuxarm64"
+		"Linux"  | "alpha"   | "exotic"
+		"Linux"  | "i64"     | "exotic"
+		"Linux"  | "ppc"     | "exotic"
+		"Linux"  | "ppc64le" | "exotic"
+		"Linux"  | "ppc64el" | "exotic"
+		"Linux"  | "s390"    | "exotic"
+		"Linux"  | "s390x"   | "exotic"
 		"Linux"  | ""        | "exotic"
 		"Darwin" | "x86_64"  | "darwinx64"
 		"Darwin" | "arm64"   | "darwinarm64"
 		"Darwin" | ""        | "darwinx64"
 		"MSYS64" | "i686"    | "msys64"
 		"MSYS64" | ""        | "msys64"
-    "Linux"  | "ppc64le" | "exotic"
 	}
 
 	def "should enable rosetta 2 compatibility mode with environment variable"() {


### PR DESCRIPTION
Only fall back on Linuxx64 on platforms not mentioned in
https://github.com/torvalds/linux/blob/5bfc75d92efd494db37f5c4c173d3639d4772966/tools/perf/scripts/python/Perf-Trace-Util/lib/Perf/Trace/Util.py#L56
(excluding the i*86 platforms).
This prevents the installation of a x86_64 JDK on PowerPC (and multiple other platforms).

Fixes #1038.