### PR TITLE
Sanitise noise from metadata headers file

### DIFF
--- a/src/main/bash/sdkman-install.sh
+++ b/src/main/bash/sdkman-install.sh
@@ -115,7 +115,7 @@ function __sdkman_install_local_version() {
 
 function __sdkman_download() {
 	local candidate version archives_folder
-	local headers_file
+	local headers_file tmp_headers_file
 
 	candidate="$1"
 	version="$2"
@@ -129,6 +129,7 @@ function __sdkman_download() {
 		local download_url="${SDKMAN_CANDIDATES_API}/broker/download/${candidate}/${version}/${platform_parameter}"
 		local base_name="${candidate}-${version}"
 		local zip_archive_target="${SDKMAN_DIR}/archives/${base_name}.zip"
+		tmp_headers_file="${SDKMAN_DIR}/tmp/${base_name}.headers.tmp"
 		headers_file="${metadata_folder}/${base_name}.headers"
 
 		# pre-installation hook: implements function __sdkman_pre_installation_hook
@@ -150,7 +151,8 @@ function __sdkman_download() {
 		echo ""
 
 		# download binary
-		__sdkman_secure_curl_download "${download_url}" --output "${binary_input}" --dump-header "${headers_file}"
+		__sdkman_secure_curl_download "${download_url}" --output "${binary_input}" --dump-header "${tmp_headers_file}"
+		grep '^X-Sdkman' "${tmp_headers_file}" > "${headers_file}"
 		__sdkman_echo_debug "Downloaded binary to: ${binary_input} (HTTP headers written to: ${headers_file})"
 
 		# post-installation hook: implements function __sdkman_post_installation_hook


### PR DESCRIPTION
On the download of a binary, the curl headers dump is now written to a temporary file. In retrospect, we sanitise this before writing it to the `~/.sdkman/var/metadata` folder. Only lines starting with `X-Sdkman` will now be recorded.