### PR TITLE
Allow `~/.config/sdkman/config` to override `~/.sdkman/etc/config`

### DIFF
--- a/src/main/bash/sdkman-config.sh
+++ b/src/main/bash/sdkman-config.sh
@@ -26,5 +26,5 @@ function __sdk_config() {
 		return 1
 	fi
 
-	"${editor[@]}" "${SDKMAN_DIR}/.sdkmanrc"
+	"${editor[@]}" "${SDKMAN_DIR}/etc/config"
 }

--- a/src/main/bash/sdkman-config.sh
+++ b/src/main/bash/sdkman-config.sh
@@ -26,5 +26,5 @@ function __sdk_config() {
 		return 1
 	fi
 
-	"${editor[@]}" "${SDKMAN_DIR}/etc/config"
+	"${editor[@]}" "${SDKMAN_DIR}/.sdkmanrc"
 }

--- a/src/main/bash/sdkman-init.sh
+++ b/src/main/bash/sdkman-init.sh
@@ -34,6 +34,11 @@ if [ -f "${SDKMAN_DIR}/etc/config" ]; then
 	source "${SDKMAN_DIR}/etc/config"
 fi
 
+# Load the sdkman user config if it exists.
+if [ -f "${HOME}/.sdkmanrc" ]; then
+	source "${SDKMAN_DIR}/.sdkmanrc"
+fi
+
 # infer platform
 function infer_platform() {
 	local kernel

--- a/src/main/bash/sdkman-init.sh
+++ b/src/main/bash/sdkman-init.sh
@@ -35,8 +35,8 @@ if [ -f "${SDKMAN_DIR}/etc/config" ]; then
 fi
 
 # Load the sdkman user config if it exists.
-if [ -f "${HOME}/.sdkmanrc" ]; then
-	source "${SDKMAN_DIR}/.sdkmanrc"
+if [ -f "${HOME}/.sdkmanconfig" ]; then
+	source "${HOME}/.sdkmanconfig"
 fi
 
 # infer platform

--- a/src/main/bash/sdkman-init.sh
+++ b/src/main/bash/sdkman-init.sh
@@ -35,8 +35,8 @@ if [ -f "${SDKMAN_DIR}/etc/config" ]; then
 fi
 
 # Load the sdkman user config if it exists.
-if [ -f "${HOME}/.sdkmanconfig" ]; then
-	source "${HOME}/.sdkmanconfig"
+if [ -f "${HOME}/.config/sdkman/config" ]; then
+	source "${HOME}/.config/sdkman/config"
 fi
 
 # infer platform

--- a/src/main/bash/sdkman-main.sh
+++ b/src/main/bash/sdkman-main.sh
@@ -96,8 +96,8 @@ function sdk() {
 	fi
 
 	# Load the sdkman user config if it exists.
-	if [ -f "${HOME}/.sdkmanrc" ]; then
-		source "${SDKMAN_DIR}/.sdkmanrc"
+	if [ -f "${HOME}/.sdkmanconfig" ]; then
+		source "${HOME}/.sdkmanconfig"
 	fi
 
 	# no command provided

--- a/src/main/bash/sdkman-main.sh
+++ b/src/main/bash/sdkman-main.sh
@@ -95,6 +95,11 @@ function sdk() {
 		source "${SDKMAN_DIR}/etc/config"
 	fi
 
+	# Load the sdkman user config if it exists.
+	if [ -f "${HOME}/.sdkmanrc" ]; then
+		source "${SDKMAN_DIR}/.sdkmanrc"
+	fi
+
 	# no command provided
 	if [[ -z "$COMMAND" ]]; then
 		__sdk_help

--- a/src/main/bash/sdkman-main.sh
+++ b/src/main/bash/sdkman-main.sh
@@ -96,8 +96,8 @@ function sdk() {
 	fi
 
 	# Load the sdkman user config if it exists.
-	if [ -f "${HOME}/.sdkmanconfig" ]; then
-		source "${HOME}/.sdkmanconfig"
+	if [ -f "${HOME}/.config/sdkman/config" ]; then
+		source "${HOME}/.config/sdkman/config"
 	fi
 
 	# no command provided


### PR DESCRIPTION
Because the current approach is very dotfiles unfriendly.

Fixes #941