### PR TITLE
Replace template tag with version

### DIFF
--- a/src/jreleaser/distributions/sdkman-cli/brew/formula.rb.tpl
+++ b/src/jreleaser/distributions/sdkman-cli/brew/formula.rb.tpl
@@ -30,6 +30,6 @@ class {{brewFormulaName}} < Formula
   end
 
   test do
-    assert_match {{projectVersion}}, shell_output("export SDKMAN_DIR=#{libexec} && source #{libexec}/bin/sdkman-init.sh && sdk version")
+    assert_match version, shell_output("export SDKMAN_DIR=#{libexec} && source #{libexec}/bin/sdkman-init.sh && sdk version")
   end
 end


### PR DESCRIPTION
@marc0der Just tried to install SDKMAN! via Homebrew and there is still some tiny error which prevents installing it.

{{projectVersion}} was expanded without quotes, resulting in the number `5.14.2` which not even in Ruby is a valid number :D.

I'm now using the `version` attribute, which contains the correct version.