### PR TITLE
Do not trigger beta releases on changes to GH workflows

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - .github/workflows/*
 
 jobs:
   pre-release:


### PR DESCRIPTION
/cc @marc0der This one is for you :).

This basically prevents triggering beta releases on workflow changes.