### PR TITLE
#1087 Fix sdkman_auto_env when PROMPT_COMMAND ends with semicolon

### DIFF
--- a/src/main/bash/sdkman-init.sh
+++ b/src/main/bash/sdkman-init.sh
@@ -225,8 +225,9 @@ if [[ "$sdkman_auto_env" == "true" ]]; then
 
 			export SDKMAN_OLD_PWD="$PWD"
 		}
-
-		[[ -z "$PROMPT_COMMAND" ]] && PROMPT_COMMAND="sdkman_auto_env" || PROMPT_COMMAND="${PROMPT_COMMAND%\;};sdkman_auto_env"
+		
+		trimmed_prompt_command="${PROMPT_COMMAND%"${PROMPT_COMMAND##*[![:space:]]}"}"
+		[[ -z "$trimmed_prompt_command" ]] && PROMPT_COMMAND="sdkman_auto_env" || PROMPT_COMMAND="${trimmed_prompt_command%\;};sdkman_auto_env"
 	fi
 
 	sdkman_auto_env


### PR DESCRIPTION
Remove double semicolon problem
Without this fix there may be a message with double semicolon:
bash: PROMPT_COMMAND: line 0: `history -a; history -n; ;sdkman_auto_env'