### PR TITLE
fix(completion): fix static analysis shellcheck errors

### DIFF
--- a/contrib/completion/bash/sdk
+++ b/contrib/completion/bash/sdk
@@ -33,7 +33,7 @@ __sdkman_complete_command() {
 			done
 			;;
 		install|i|list|ls)
-			candidates=${SDKMAN_CANDIDATES[@]}
+			candidates=("${SDKMAN_CANDIDATES[@]}")
 			;;
 		env|e)
 			candidates=("init" "install" "clear")
@@ -49,7 +49,7 @@ __sdkman_complete_command() {
 			;;
 	esac
 
-	COMPREPLY=($(compgen -W "${candidates[*]}" -- "$current_word"))
+	read -r -a COMPREPLY < <(compgen -W "${candidates[*]}" -- "$current_word")
 }
 
 __sdkman_complete_candidate_version() {
@@ -76,7 +76,7 @@ __sdkman_complete_candidate_version() {
 			;;
 	esac
 
-	COMPREPLY=($(compgen -W "${candidates[*]}" -- "$candidate_version"))
+	read -r -a COMPREPLY < <(compgen -W "${candidates[*]}" -- "$candidate_version")
 }
 
 complete -o default -F _sdk sdk


### PR DESCRIPTION
In ./contrib/completion/bash/sdk line 36:
			candidates=${SDKMAN_CANDIDATES[@]}
                        ^--------^ SC2178 (warning): Variable was used as an array but is now assigned a string.
                                   ^---------------------^ SC2124 (warning): Assigning an array to a string! Assign as array, or use * instead of @ to concatenate.

In ./contrib/completion/bash/sdk line 52:
	COMPREPLY=($(compgen -W "${candidates[*]}" -- "$current_word"))
                   ^-- SC2207 (warning): Prefer mapfile or read -a to split command output (or quote to avoid splitting).

In ./contrib/completion/bash/sdk line 79:
	COMPREPLY=($(compgen -W "${candidates[*]}" -- "$candidate_version"))
                   ^-- SC2207 (warning): Prefer mapfile or read -a to split command output (or quote to avoid splitting).

For more information:
  https://www.shellcheck.net/wiki/SC2124 -- Assigning an array to a string! A...
  https://www.shellcheck.net/wiki/SC2178 -- Variable was used as an array but...
  https://www.shellcheck.net/wiki/SC2207 -- Prefer mapfile or read -a to spli...