### PR TITLE
sdkman-list missing versions

### DIFF
--- a/src/main/bash/sdkman-list.sh
+++ b/src/main/bash/sdkman-list.sh
@@ -75,13 +75,13 @@ function __sdkman_offline_list() {
 	__sdkman_echo_yellow "Offline: only showing installed ${candidate} versions"
 	__sdkman_echo_no_colour "--------------------------------------------------------------------------------"
 
-	local versions=($(echo ${versions_csv//,/\\n} | tac))
-	for version in "${versions[@]}"; do
-		if [[ -n "${version}" ]]; then
-			if [[ "${version}" == "$CURRENT" ]]; then
-				__sdkman_echo_no_colour " > ${version}"
+	local versions=($(echo ${versions_csv//,/ }))
+	for ((i = ${#versions} - 1; i >= 0; i--)); do
+		if [[ -n "${versions[${i}]}" ]]; then
+			if [[ "${versions[${i}]}" == "$CURRENT" ]]; then
+				__sdkman_echo_no_colour " > ${versions[@]:$i:1}"
 			else
-				__sdkman_echo_no_colour " * ${version}"
+				__sdkman_echo_no_colour " * ${versions[@]:$i:1}"
 			fi
 		fi
 	done

--- a/src/main/bash/sdkman-list.sh
+++ b/src/main/bash/sdkman-list.sh
@@ -79,9 +79,9 @@ function __sdkman_offline_list() {
 	for ((i = ${#versions} - 1; i >= 0; i--)); do
 		if [[ -n "${versions[${i}]}" ]]; then
 			if [[ "${versions[${i}]}" == "$CURRENT" ]]; then
-				__sdkman_echo_no_colour " > ${versions[${i}]}"
+				__sdkman_echo_no_colour " > ${versions[@]:$i:1}"
 			else
-				__sdkman_echo_no_colour " * ${versions[${i}]}"
+				__sdkman_echo_no_colour " * ${versions[@]:$i:1}"
 			fi
 		fi
 	done

--- a/src/main/bash/sdkman-list.sh
+++ b/src/main/bash/sdkman-list.sh
@@ -75,13 +75,13 @@ function __sdkman_offline_list() {
 	__sdkman_echo_yellow "Offline: only showing installed ${candidate} versions"
 	__sdkman_echo_no_colour "--------------------------------------------------------------------------------"
 
-	local versions=($(echo ${versions_csv//,/ }))
-	for ((i = ${#versions} - 1; i >= 0; i--)); do
-		if [[ -n "${versions[${i}]}" ]]; then
-			if [[ "${versions[${i}]}" == "$CURRENT" ]]; then
-				__sdkman_echo_no_colour " > ${versions[@]:$i:1}"
+	local versions=($(echo ${versions_csv//,/\\n} | tac))
+	for version in "${versions[@]}"; do
+		if [[ -n "${version}" ]]; then
+			if [[ "${version}" == "$CURRENT" ]]; then
+				__sdkman_echo_no_colour " > ${version}"
 			else
-				__sdkman_echo_no_colour " * ${versions[@]:$i:1}"
+				__sdkman_echo_no_colour " * ${version}"
 			fi
 		fi
 	done


### PR DESCRIPTION
The starting index for an array is 1 for zsh by default and 0 for bash

https://zsh.sourceforge.io/Doc/Release/Parameters.html#Array-Subscripts


fix #1125