### PR TITLE
Fix main function for native commands

### DIFF
--- a/src/main/bash/sdkman-main.sh
+++ b/src/main/bash/sdkman-main.sh
@@ -141,39 +141,17 @@ function sdk() {
 	# Native commands found under libexec
 	local native_command="${SDKMAN_DIR}/libexec/${COMMAND}"
 	
-	# Internal commands use underscores rather than hyphens
-	local converted_command_name=$(echo "$COMMAND" | tr '-' '_')
-
 	if [ -f "$native_command" ]; then
-		# Available as native command
-		if [ -z "$QUALIFIER" ]; then
-			"$native_command"
-		elif [ -z "$3" ]; then
-			"$native_command" "$QUALIFIER"
-		elif [ -z "$4" ]; then
-			"$native_command" "$QUALIFIER" "$3"
-		elif [ -z "$5" ]; then
-			"$native_command" "$QUALIFIER" "$3" "$4"
-		elif [ -z "$6" ]; then
-			"$native_command" "$QUALIFIER" "$3" "$4" "$5"
-		elif [ -z "$7" ]; then
-			"$native_command" "$QUALIFIER" "$3" "$4" "$5" "$6"
-		elif [ -z "$8" ]; then
-			"$native_command" "$QUALIFIER" "$3" "$4" "$5" "$6" "$7"
-		elif [ -z "$9" ]; then
-			"$native_command" "$QUALIFIER" "$3" "$4" "$5" "$6" "$7" "$8"
-		elif [ -z "$10" ]; then
-			"$native_command" "$QUALIFIER" "$3" "$4" "$5" "$6" "$7" "$8" "$9"
-		else
-			___sdkman_help
-		fi
-		final_rc=$?
+		"$native_command" "${@:2}"
 
 	elif [ -n "$CMD_FOUND" ]; then
+		# Internal commands use underscores rather than hyphens
+		local converted_command_name=$(echo "$COMMAND" | tr '-' '_')
+
 		# Available as a shell function
 		__sdk_"$converted_command_name" "$QUALIFIER" "$3" "$4"
-		final_rc=$?
 	fi
+	final_rc=$?
 
 	# Attempt upgrade after all is done
 	if [[ "$COMMAND" != "selfupdate" && "$sdkman_selfupdate_feature" == "true" && "$sdkman_auto_update" == "true" ]]; then

--- a/src/main/bash/sdkman-main.sh
+++ b/src/main/bash/sdkman-main.sh
@@ -60,11 +60,6 @@ function sdk() {
 		;;
 	esac
 
-	if [[ "$COMMAND" == "home" ]]; then
-		__sdk_home "$QUALIFIER" "$3"
-		return $?
-	fi
-
 	# Left here for legacy purposes, issue #912 on Github
 	if [[ "$COMMAND" == "completion" ]]; then
 		return 0

--- a/src/main/bash/sdkman-main.sh
+++ b/src/main/bash/sdkman-main.sh
@@ -123,8 +123,7 @@ function sdk() {
 	fi
 
 	# Check whether the candidate exists
-	local sdkman_valid_candidate=$(echo ${SDKMAN_CANDIDATES[@]} | grep -w "$QUALIFIER")
-	if [[ -n "$QUALIFIER" && "$COMMAND" != "help" && "$COMMAND" != "offline" && "$COMMAND" != "flush" && "$COMMAND" != "selfupdate" && "$COMMAND" != "env" && "$COMMAND" != "completion" && "$COMMAND" != "edit" && -z "$sdkman_valid_candidate" ]]; then
+	if [[ -n "$QUALIFIER" && "$COMMAND" != "help" && "$COMMAND" != "offline" && "$COMMAND" != "flush" && "$COMMAND" != "selfupdate" && "$COMMAND" != "env" && "$COMMAND" != "completion" && "$COMMAND" != "edit" && "$COMMAND" != "home" && -z $(echo ${SDKMAN_CANDIDATES[@]} | grep -w "$QUALIFIER") ]]; then
 		echo ""
 		__sdkman_echo_red "Stop! $QUALIFIER is not a valid candidate."
 		return 1
@@ -153,8 +152,20 @@ function sdk() {
 			"$native_command" "$QUALIFIER"
 		elif [ -z "$4" ]; then
 			"$native_command" "$QUALIFIER" "$3"
-		else
+		elif [ -z "$5" ]; then
 			"$native_command" "$QUALIFIER" "$3" "$4"
+		elif [ -z "$6" ]; then
+			"$native_command" "$QUALIFIER" "$3" "$4" "$5"
+		elif [ -z "$7" ]; then
+			"$native_command" "$QUALIFIER" "$3" "$4" "$5" "$6"
+		elif [ -z "$8" ]; then
+			"$native_command" "$QUALIFIER" "$3" "$4" "$5" "$6" "$7"
+		elif [ -z "$9" ]; then
+			"$native_command" "$QUALIFIER" "$3" "$4" "$5" "$6" "$7" "$8"
+		elif [ -z "$10" ]; then
+			"$native_command" "$QUALIFIER" "$3" "$4" "$5" "$6" "$7" "$8" "$9"
+		else
+			___sdkman_help
 		fi
 		final_rc=$?
 

--- a/src/main/bash/sdkman-main.sh
+++ b/src/main/bash/sdkman-main.sh
@@ -16,6 +16,14 @@
 #   limitations under the License.
 #
 
+function ___sdkman_help() {
+	if [[ -f "$SDKMAN_DIR/libexec/help" ]]; then
+		"$SDKMAN_DIR/libexec/help"
+	else
+		__sdk_help
+	fi
+}
+
 function sdk() {
 
 	COMMAND="$1"
@@ -87,7 +95,7 @@ function sdk() {
 
 	# no command provided
 	if [[ -z "$COMMAND" ]]; then
-		__sdk_help
+		___sdkman_help
 		return 1
 	fi
 
@@ -111,7 +119,7 @@ function sdk() {
 		echo ""
 		__sdkman_echo_red "Invalid command: $COMMAND"
 		echo ""
-		__sdk_help
+		___sdkman_help
 	fi
 
 	# Check whether the candidate exists

--- a/src/main/bash/sdkman-main.sh
+++ b/src/main/bash/sdkman-main.sh
@@ -60,11 +60,6 @@ function sdk() {
 		;;
 	esac
 
-	# Left here for legacy purposes, issue #912 on Github
-	if [[ "$COMMAND" == "completion" ]]; then
-		return 0
-	fi
-
 	#
 	# Various sanity checks and default settings
 	#


### PR DESCRIPTION
These are steps to improve the main `sdk` function to delegate to the currently available native commands.

- Remove home command hack
- Remove legacy completion command workaround
- Display native help falling back to legacy help
- Give precedence to native home command
- Propagation of up to ten params to a native command
