### PR TITLE
chore: Upgrade to Gradle 8.0.1, setup caching for GH workflows

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
+          cache: 'gradle'
       - name: Run tests
         run: ./gradlew clean test --info
       - name: Set short git hash

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,6 +12,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
+          cache: 'gradle'
       - name: Run with Gradle
         run: ./gradlew clean test --info
       - uses: kentaro-m/auto-assign-action@v1.2.4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: '11'
+        cache: 'gradle'
     - name: Run tests
       run: ./gradlew clean test --info
     - name: Build artifacts

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Upgrade Gradle to 8.0.1 and sets up Gradle caching for `actions/setup-java@v3` steps.