### PR TITLE
chore: Improve `sdk env` error handling

### DIFF
--- a/src/main/bash/sdkman-env.sh
+++ b/src/main/bash/sdkman-env.sh
@@ -54,8 +54,23 @@ function __sdkman_load_env() {
 		return 1
 	fi
 
-	__sdkman_env_each_candidate "$sdkmanrc" "__sdk_use" && 
+	__sdkman_env_each_candidate "$sdkmanrc" "__sdkman_check_and_use" && 
 		SDKMAN_ENV=$PWD
+}
+
+function __sdkman_check_and_use() {
+	local -r candidate=$1
+	local -r version=$2
+
+	if [[ ! -d "${SDKMAN_CANDIDATES_DIR}/${candidate}/${version}" ]]; then
+		__sdkman_echo_red "Stop! $candidate $version is not installed."
+		echo ""
+		__sdkman_echo_yellow "Run 'sdk env install' to install it."
+
+		return 1
+	fi
+
+	__sdk_use "$candidate" "$version"
 }
 
 function __sdkman_create_env_file() {
@@ -130,7 +145,7 @@ function __sdkman_env_each_candidate() {
 			return 1
 		fi
 
-		$func "${normalised_line%=*}" "${normalised_line#*=}"
+		$func "${normalised_line%=*}" "${normalised_line#*=}" || return
 	done < "$filepath"
 }
 

--- a/src/test/groovy/sdkman/specs/EnvCommandSpec.groovy
+++ b/src/test/groovy/sdkman/specs/EnvCommandSpec.groovy
@@ -357,6 +357,29 @@ class EnvCommandSpec extends SdkmanEnvSpecification {
 		}
 	}
 
+	def "should issue an error when .sdkmanrc contains a candidate version which is not installed"() {
+		given:
+		bash = sdkmanBashEnvBuilder
+				.withVersionCache("x.y.z")
+				.withOfflineMode(true)
+				.build()
+
+		new File(bash.workDir, ".sdkmanrc").text = "groovy=2.4.1"
+
+		bash.start()
+		bash.execute("source $bootstrapScript")
+
+		when:
+		bash.execute("sdk env")
+
+		then:
+		verifyAll(bash) {
+			status == 1
+			output.contains("Stop! groovy 2.4.1 is not installed.")
+			output.contains("Run 'sdk env install' to install it.")
+		}
+	}
+
 	def "should support blank lines, comments and inline comments"() {
 		given:
 		new FileTreeBuilder(candidatesDirectory).with {


### PR DESCRIPTION
This change improves `sdk env`'s error handling and displays the correct step to take in case one or more dependencies are not found.

<img width="414" alt="image" src="https://user-images.githubusercontent.com/1562019/225932907-62e96659-5293-4384-b617-556c3b017458.png">

/cc @marc0der 