### PR TITLE
Add missing quotes when handling file paths within install command

### DIFF
--- a/src/main/bash/sdkman-install.sh
+++ b/src/main/bash/sdkman-install.sh
@@ -120,7 +120,7 @@ function __sdkman_download() {
 	version="$2"
 
 	metadata_folder="${SDKMAN_DIR}/var/metadata"
-	mkdir -p ${metadata_folder}
+	mkdir -p "${metadata_folder}"
 		
 	local platform_parameter="$SDKMAN_PLATFORM"
 	local download_url="${SDKMAN_CANDIDATES_API}/broker/download/${candidate}/${version}/${platform_parameter}"
@@ -228,5 +228,5 @@ function __sdkman_checksum_zip() {
 				__sdkman_echo_no_colour "Not able to perform checksum verification at this time."
 			fi
 		fi
-  	done < ${headers_file}
+  	done < "${headers_file}"
 }


### PR DESCRIPTION
This PR resolves issues when SDKMAN_DIR has whitespaces (see https://github.com/sdkman/sdkman-cli/issues/1208).