### PR TITLE
fix: Quote `$SDKMAN_DIR` in version subcommand

### DIFF
--- a/src/main/bash/sdkman-version.sh
+++ b/src/main/bash/sdkman-version.sh
@@ -17,7 +17,7 @@
 #
 
 function __sdk_version() {
-    local version=$(cat $SDKMAN_DIR/var/version)
+	local version=$(cat "$SDKMAN_DIR/var/version")
 	echo ""
 	__sdkman_echo_yellow "SDKMAN $version"
 }


### PR DESCRIPTION
With this change, the `version` subcommand now works if `$SDKMAN_DIR` includes newlines, etc.