### PR TITLE
Fix array indexing and length handling

### DIFF
--- a/src/main/bash/sdkman-list.sh
+++ b/src/main/bash/sdkman-list.sh
@@ -76,7 +76,7 @@ function __sdkman_offline_list() {
 	__sdkman_echo_no_colour "--------------------------------------------------------------------------------"
 
 	local versions=($(echo ${versions_csv//,/ }))
-	for ((i = ${#versions} - 1; i >= 0; i--)); do
+	for ((i = ${#versions[@]}; i > 0; i--)); do
 		if [[ -n "${versions[${i}]}" ]]; then
 			if [[ "${versions[${i}]}" == "$CURRENT" ]]; then
 				__sdkman_echo_no_colour " > ${versions[${i}]}"


### PR DESCRIPTION
Cf. https://sdkman.slack.com/archives/CJTNQA94M/p1706573532033689?thread_ts=1706516271.626039&cid=CJTNQA94M

- Array indexing is wrong, it starts at 1 (not 0) and ends at the highest index, not at array length -1. You have both in C or Java, but shell is different.
- Executed in bash the `${#versions}` is - for whatever reason - restricted to four bits. So the maximum value is 15. If the versions array is > 15, you have to use `${#versions[@]}` instead (cf. https://linuxhandbook.com/array-length-bash/).

<!-- To raise a new Pull Request, the following prerequisites need to be met. Please tick before proceeding: -->

- [x] a GitHub Issue was opened for this feature / bug.
- [ ] test coverage was added (Cucumber or Spock as appropriate).

NOTE: I have no idea how to provide a Cucumber test for this case. But I am happy to learn about it, in particular how to test the array size in bash if it is > 15. Feel free to get in touch with me about it.


Fixes #1273
