### PR TITLE
Follow symlinks for scripts and extension files

### DIFF
--- a/src/main/bash/sdkman-init.sh
+++ b/src/main/bash/sdkman-init.sh
@@ -72,7 +72,7 @@ fi
 # <https://github.com/sdkman/sdkman-extensions>.
 OLD_IFS="$IFS"
 IFS=$'\n'
-scripts=($(find "${SDKMAN_DIR}/src" "${SDKMAN_DIR}/ext" -type f -name 'sdkman-*.sh'))
+scripts=($(find -L "${SDKMAN_DIR}/src" "${SDKMAN_DIR}/ext" -type f -name 'sdkman-*.sh'))
 for f in "${scripts[@]}"; do
 	source "$f"
 done


### PR DESCRIPTION
Follow symlinks in `~/.sdkman/ext` and `~/.sdkman/ext`.

This supports the use-case of users who wish to keep scripts and extensions in a dotfiles repo. 

- [ *] a GitHub Issue was opened for this feature / bug.
- [ ] test coverage was added (Cucumber or Spock as appropriate).

Fixes #1279
