### PR TITLE
In __sdkman_echo_paged(), remove forced less(1) call

### DIFF
--- a/src/main/bash/sdkman-utils.sh
+++ b/src/main/bash/sdkman-utils.sh
@@ -68,8 +68,6 @@ function __sdkman_secure_curl_with_timeouts() {
 function __sdkman_echo_paged() {
 	if [[ -n "$PAGER" ]]; then
 		echo "$@" | eval "$PAGER"
-	elif command -v less >& /dev/null; then
-		echo "$@" | less
 	else
 		echo "$@"
 	fi


### PR DESCRIPTION
Obey the standard variable PAGER. If set, use it. If unset, no paging is used. For example, if the user does not want to page the results, they can call in the standard shell:

  PAGER=  <command>

<!-- To raise a new Pull Request, the following prerequisites need to be met. Please tick before proceeding: -->

- [ ] a GitHub Issue was opened for this feature / bug.
- [ ] test coverage was added (Cucumber or Spock as appropriate).

Fixes #XXX
