### PR TITLE
In __sdkman_list_versions() strip EOL whitespace.

### DIFF
--- a/src/main/bash/sdkman-list.sh
+++ b/src/main/bash/sdkman-list.sh
@@ -44,7 +44,7 @@ function __sdkman_list_versions() {
 	if [[ "$SDKMAN_AVAILABLE" == "false" ]]; then
 		__sdkman_offline_list "$candidate" "$versions_csv"
 	else
-		__sdkman_echo_paged "$(__sdkman_secure_curl "${SDKMAN_CANDIDATES_API}/candidates/${candidate}/${SDKMAN_PLATFORM}/versions/list?current=${CURRENT}&installed=${versions_csv}")"
+		__sdkman_echo_paged "$(__sdkman_secure_curl "${SDKMAN_CANDIDATES_API}/candidates/${candidate}/${SDKMAN_PLATFORM}/versions/list?current=${CURRENT}&installed=${versions_csv}" | sed -e 's/[[:space:]]*$//')"
 	fi
 }
 


### PR DESCRIPTION
Add sed(1) to clean whitespace at the end of lines (EOL) after a curl(1) call to get a list of versions.

<!-- To raise a new Pull Request, the following prerequisites need to be met. Please tick before proceeding: -->

- [ ] a GitHub Issue was opened for this feature / bug.
- [ ] test coverage was added (Cucumber or Spock as appropriate).

Fixes #XXX
