### PR TITLE
fix: update local install length constraint

### DIFF
--- a/src/main/bash/sdkman-install.sh
+++ b/src/main/bash/sdkman-install.sh
@@ -79,7 +79,7 @@ function __sdkman_install_candidate_version() {
 function __sdkman_install_local_version() {
 	local candidate version folder version_length version_length_max
 
-	version_length_max=15
+	version_length_max=20
 
 	candidate="$1"
 	version="$2"

--- a/src/test/resources/features/local_developement_versions.feature
+++ b/src/test/resources/features/local_developement_versions.feature
@@ -68,12 +68,12 @@ Feature: Local Development Versions
 		And the candidate "groovy" version "2.1-SNAPSHOT" is not installed
 
 	Scenario: Prevent installation of a local development version for a long version
-		Given the candidate "groovy" version "2.1-SNAPSHOTLONG" is not available for download
-		And I have a local candidate "groovy" version "2.1-SNAPSHOTLONG" at relative path "some/relative/path/to/groovy"
+		Given the candidate "groovy" version "2.1-SNAPSHOTEXTRALONG" is not available for download
+		And I have a local candidate "groovy" version "2.1-SNAPSHOTEXTRALONG" at relative path "some/relative/path/to/groovy"
 		And the system is bootstrapped
-		When I enter "sdk install groovy 2.1-SNAPSHOTLONG some/relative/path/to/groovy"
-		Then I see "Invalid version! 2.1-SNAPSHOTLONG with length 16 exceeds max of 15!"
-		And the candidate "groovy" version "2.1-SNAPSHOTLONG" is not installed
+		When I enter "sdk install groovy 2.1-SNAPSHOTEXTRALONG some/relative/path/to/groovy"
+		Then I see "Invalid version! 2.1-SNAPSHOTEXTRALONG with length 21 exceeds max of 20!"
+		And the candidate "groovy" version "2.1-SNAPSHOTEXTRALONG" is not installed
 
 	Scenario: Allow installation of a local development version for longest possible version
 		Given the candidate "groovy" version "2.1-SNAPSHOT-XX" is not available for download


### PR DESCRIPTION
Updates length from 15 (shorter than 12 existing 'java' candidates) to 20 (longer than any existing 'java' candidate, as `23.1.10.r21-mandrel` is 19 characters).

- [x] a GitHub Issue was opened for this feature / bug.
- [x] test coverage was added (Cucumber or Spock as appropriate).

Fixes: #1526