### PR TITLE
fix: preserve global default during sdk env install

### DIFF
--- a/src/main/bash/sdkman-env.sh
+++ b/src/main/bash/sdkman-env.sh
@@ -39,8 +39,31 @@ function __sdkman_setup_env() {
 		return 1
 	fi
 
-	sdkman_auto_answer="true" USE="n" __sdkman_env_each_candidate "$sdkmanrc" "__sdk_install"
+	__sdkman_env_each_candidate "$sdkmanrc" "__sdkman_install_keeping_default"
 	__sdkman_load_env "$sdkmanrc"
+}
+
+function __sdkman_install_keeping_default() {
+	local candidate version current_link previous_default
+	candidate="$1"
+	version="$2"
+	current_link="${SDKMAN_CANDIDATES_DIR}/${candidate}/current"
+	previous_default=""
+
+	if [[ -L "$current_link" ]]; then
+		previous_default="$(basename "$(readlink "$current_link")")"
+	fi
+
+	sdkman_auto_answer="true" USE="n" __sdk_install "$candidate" "$version" || return 1
+
+	if [[ -n "$previous_default" && -L "$current_link" ]]; then
+		local new_default
+		new_default="$(basename "$(readlink "$current_link")")"
+		if [[ "$new_default" != "$previous_default" ]]; then
+			rm -f "$current_link"
+			ln -s "$previous_default" "$current_link"
+		fi
+	fi
 }
 
 function __sdkman_load_env() {

--- a/src/test/groovy/sdkman/steps/stub_steps.groovy
+++ b/src/test/groovy/sdkman/steps/stub_steps.groovy
@@ -26,7 +26,13 @@ And(~'^the candidate "([^"]*)" version "([^"]*)" is available for download$') { 
 	primeEndpointWithString("/hooks/post/${candidate}/${version}/${UnixUtils.inferPlatform()}", postInstallationHookSuccess())
 }
 
-And(~'^the candidate "([^"]*)" version "([^"]*)" is available for download with checksum "([^"]*)" using algorithm "([^"]*)"$') { 
+And(~'^the candidate "([^"]*)" version "([^"]*)" is available for download with a perturbing post-installation hook$') { String candidate, String version ->
+	primeEndpointWithString("/candidates/validate/${candidate}/${version}/${UnixUtils.inferPlatform()}", "valid")
+	primeDownloadFor(SERVICE_UP_URL, candidate, version, UnixUtils.inferPlatform())
+	primeEndpointWithString("/hooks/post/${candidate}/${version}/${UnixUtils.inferPlatform()}", postInstallationHookPerturbing())
+}
+
+And(~'^the candidate "([^"]*)" version "([^"]*)" is available for download with checksum "([^"]*)" using algorithm "([^"]*)"$') {
 	String candidate, String version, String checksum, String algorithm ->
 	primeEndpointWithString("/candidates/validate/${candidate}/${version}/${UnixUtils.inferPlatform()}", "valid")
 	primeDownloadFor(SERVICE_UP_URL, candidate, version, UnixUtils.inferPlatform(), ["X-Sdkman-Checksum-${algorithm}": "${checksum}"])

--- a/src/test/groovy/sdkman/stubs/HookResponses.groovy
+++ b/src/test/groovy/sdkman/stubs/HookResponses.groovy
@@ -22,4 +22,16 @@ function __sdkman_post_installation_hook {
 }
 '''
 	}
+
+	static postInstallationHookPerturbing() {
+		'''\
+#!/usr/bin/env bash
+function __sdkman_post_installation_hook {
+	mv -f $binary_input $zip_output
+	unset sdkman_auto_answer
+	echo "Post-installation hook success"
+	return 0
+}
+'''
+	}
 }

--- a/src/test/resources/features/per_project_configuration.feature
+++ b/src/test/resources/features/per_project_configuration.feature
@@ -38,6 +38,16 @@ Feature: Per-project configuration
 		And the candidate "groovy" version "2.4.1" is in use
 		And the candidate "groovy" version "2.0.5" should be the default
 
+	Scenario: The env install subcommand preserves the global default when the post-installation hook perturbs shell state
+		Given the file ".sdkmanrc" exists and contains "groovy=2.4.1"
+		And the candidate "groovy" version "2.0.5" is already installed and default
+		And the candidate "groovy" version "2.4.1" is available for download with a perturbing post-installation hook
+		And the system is bootstrapped
+		When I enter "sdk env install"
+		Then I see "Done installing!"
+		And the candidate "groovy" version "2.4.1" is installed
+		And the candidate "groovy" version "2.0.5" should be the default
+
 	Scenario: The env install subcommand is issued without an sdkman project configuration present
 		Given the system is bootstrapped
 		When I enter "sdk env install"


### PR DESCRIPTION
Closes #1457

## Summary

`sdk env install` could silently overwrite the user's global default for a candidate when installing the version pinned in `.sdkmanrc`. This PR makes the global default robust against shell-state perturbation by sourced post-installation hooks.

## Root cause

`__sdkman_setup_env` relied on inline variable prefixes to suppress the "set as default?" prompt:

```bash
sdkman_auto_answer="true" USE="n" __sdkman_env_each_candidate "$sdkmanrc" "__sdk_install"
```

`__sdk_install` calls `__sdkman_install_candidate_version`, which sources the remote post-installation hook before checking `sdkman_auto_answer`. Real-world hooks (notably the Java repackaging hook) end up perturbing shell state — e.g. by triggering the `sdkman_auto_env` `chpwd` handler, or by mutating variables during sourcing — which strips the inline overlay. With the global config value `sdkman_auto_answer=false` re-emerging, the prompt branch runs; `read USE` reads from the redirected `.sdkmanrc` stdin, hits EOF, sets `USE=""`, and the new version is linked as the global default.

## Fix

`sdkman-env.sh` no longer depends on inline-env-prefix surviving across a sourced remote hook. A small wrapper, `__sdkman_install_keeping_default`, captures the current `current` symlink target before installing and restores it if `__sdk_install` ended up changing it. First-install behaviour (no prior default) is unchanged.

## Test plan

- [x] New cucumber scenario in `per_project_configuration.feature` reproduces the bug via a "perturbing" post-installation hook stub that runs `unset sdkman_auto_answer` — fails on the previous `sdkman-env.sh:42`, passes with this fix.
- [x] Full test suite green (`./gradlew test`) — 163 tests, 0 failures, 0 errors.
- [x] Existing per-project scenarios still pass.